### PR TITLE
[FEATURE] support for google structured data (siteSearch and Breadcrumb)

### DIFF
--- a/Classes/UserFunc/StructuredData.php
+++ b/Classes/UserFunc/StructuredData.php
@@ -1,0 +1,177 @@
+<?php
+namespace Clickstorm\CsSeo\UserFunc;
+
+/***************************************************************
+ *
+ *  Copyright notice
+ *
+ *  (c) 2016 Alexander Wahl <alexander.wahl@setusoft.de>, SETU GmbH
+ *
+ *  All rights reserved
+ *
+ *  This script is part of the TYPO3 project. The TYPO3 project is
+ *  free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  The GNU General Public License can be found at
+ *  http://www.gnu.org/copyleft/gpl.html.
+ *
+ *  This script is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  This copyright notice MUST APPEAR in all copies of the script!
+ ***************************************************************/
+
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Frontend\Page\PageRepository;
+use TYPO3\CMS\Frontend\ContentObject\ContentObjectRenderer;
+
+/**
+ * Render the structured Data for Google SiteSearch and Breadcrumb
+ *
+ * @package Clickstorm\CsSeo\UserFunc
+ * @see https://developers.google.com/search/docs/guides/intro-structured-data
+ */
+class StructuredData
+{
+
+    /**
+     * @var \Clickstorm\CsSeo\Utility\TSFEUtility $tsfeUtility
+     */
+    public $tsfeUtility;
+
+    public function __construct()
+    {
+        $this->tsfeUtility = GeneralUtility::makeInstance(\Clickstorm\CsSeo\Utility\TSFEUtility::class, $GLOBALS['TSFE']->id);
+
+    }
+
+    /**
+     * check if sitesearch is enabled
+     *
+     * @return boolean
+     */
+    public static function siteSearch()
+    {
+        return (!empty($GLOBALS['TSFE']->tmpl->flatSetup['plugin.tx_csseo.structureddata.search.enable']));
+    }
+
+
+    /**
+     * Returns the json for the siteSearch
+     *
+     * @return bool|string siteSearch
+     */
+    public function getSiteSearch($content, $conf)
+    {
+        $homepage = GeneralUtility::getIndpEnv('TYPO3_REQUEST_HOST');
+
+        $cObject = GeneralUtility::makeInstance(ContentObjectRenderer::class);
+        $typoLinkConf = [
+            'parameter' => $conf['userFunc.']['pid'],
+            'forceAbsoluteUrl' => 1,
+            'additionalParams' => '&'.$conf['userFunc.']['searchterm'].'='
+        ];
+
+        $siteSearchUrl = $cObject->typoLink_URL($typoLinkConf);
+
+        $siteSearch = [
+            '@context' => 'http://schema.org',
+            '@type' => 'WebSite',
+            'url' => $homepage.'/',
+            'potentialAction' => [
+                '@type' => 'SearchAction',
+                'target' => $siteSearchUrl.'{search_term_string}',
+                'query-input' => 'required name=search_term_string',
+            ],
+        ];
+
+        return $this->wrapWithLd(json_encode($siteSearch));
+
+    }
+
+    /**
+     * Wraps $content with Json declaration
+     *
+     * @param $content
+     * @return string
+     */
+    protected function wrapWithLd($content)
+    {
+        return '<script type="application/ld+json">'.$content.'</script>';
+    }
+
+    /**
+     * check if breadcrumb is enabled
+     *
+     * @return boolean
+     */
+    public static function breadcrumb()
+    {
+        return (!empty($GLOBALS['TSFE']->tmpl->flatSetup['plugin.tx_csseo.structureddata.breadcrumb.enable']));
+    }
+
+    /**
+     * Returns the json for the serps breadcrumb
+     *
+     * @param $conf
+     * @param $content
+     * @return string
+     */
+    public function getBreadcrumb($conf, $content)
+    {
+        /** @var  \TYPO3\CMS\Frontend\Page\PageRepository $pageRepository */
+        $pageRepository = GeneralUtility::makeInstance(PageRepository::class);
+        $rootline = $pageRepository->getRootLine($GLOBALS['TSFE']->id);
+
+        $cObject = GeneralUtility::makeInstance(ContentObjectRenderer::class);
+
+        $siteLinks = array();
+
+        foreach (array_reverse($rootline) as $index => $page) {
+            $typoLinkConf = [
+                'parameter' => $page['uid'],
+                'forceAbsoluteUrl' => 1
+            ];
+
+            if ($GLOBALS['TSFE']->sys_language_uid > 0) {
+                $page = $pageRepository->getPageOverlay($page);
+            }
+
+            $siteLinks[] = [
+                'link' => $cObject->typoLink_URL($typoLinkConf),
+                'name' => $page['title'],
+            ];
+        }
+
+        $breadcrumbItems = array();
+        // remove the last element because it's the current page itself and this should NOT be included
+        // into the structured breadcrumb
+        array_pop($siteLinks);
+
+        foreach ($siteLinks as $index => $pInfo) {
+
+            $breadcrumbItems[] = [
+                '@type' => 'ListItem',
+                'position' => $index + 1,
+                'item' => [
+                    '@id' => $pInfo['link'],
+                    'name' => $pInfo['name'],
+                ],
+            ];
+        }
+
+        // assemble the json output
+        $structuredBreadcrumb = [
+            '@context' => 'http://schema.org',
+            '@type' => 'BreadcrumbList',
+            'itemListElement' => $breadcrumbItems
+        ];
+
+        return $this->wrapWithLd(json_encode($structuredBreadcrumb));
+    }
+}

--- a/Configuration/TypoScript/Setup/meta.ts
+++ b/Configuration/TypoScript/Setup/meta.ts
@@ -162,7 +162,7 @@ config {
 						file.import.data = file:current:publicUrl
 						file.height < plugin.tx_csseo.social.openGraph.image.height
 						file.width < plugin.tx_csseo.social.openGraph.image.width
-						stdWrap.dataWrap = <meta property="og:image" content="{TSFE:baseUrl}|" />
+						stdWrap.dataWrap = <meta property="og:image" content="{TSFE:baseUrl}/|" />
 					}
 				}
 
@@ -173,7 +173,7 @@ config {
 					file.import.data = path:{$plugin.tx_csseo.social.defaultImage}
 					file.height < plugin.tx_csseo.social.openGraph.image.height
 					file.width < plugin.tx_csseo.social.openGraph.image.width
-					stdWrap.dataWrap = <meta property="og:image" content="{TSFE:baseUrl}|" />
+					stdWrap.dataWrap = <meta property="og:image" content="{TSFE:baseUrl}/|" />
 				}
 			}
 
@@ -227,7 +227,7 @@ config {
 						file.import.data = file:current:publicUrl
 						file.height < plugin.tx_csseo.social.twitter.image.height
 						file.width  < plugin.tx_csseo.social.twitter.image.width
-						stdWrap.dataWrap = <meta name="twitter:image" content="{TSFE:baseUrl}|" />
+						stdWrap.dataWrap = <meta name="twitter:image" content="{TSFE:baseUrl}/|" />
 					}
 				}
 
@@ -238,7 +238,7 @@ config {
 					file.import.data = path:{$plugin.tx_csseo.social.twitter.defaultImage} // path:{$plugin.tx_csseo.social.defaultImage}
 					file.height < plugin.tx_csseo.social.twitter.image.height
 					file.width  < plugin.tx_csseo.social.twitter.image.width
-					stdWrap.dataWrap = <meta property="twitter:image" content="{TSFE:baseUrl}|" />
+					stdWrap.dataWrap = <meta property="twitter:image" content="{TSFE:baseUrl}/|" />
 				}
 			}
 		}

--- a/Configuration/TypoScript/Setup/meta.ts
+++ b/Configuration/TypoScript/Setup/meta.ts
@@ -162,7 +162,7 @@ config {
 						file.import.data = file:current:publicUrl
 						file.height < plugin.tx_csseo.social.openGraph.image.height
 						file.width < plugin.tx_csseo.social.openGraph.image.width
-						stdWrap.dataWrap = <meta property="og:image" content="{TSFE:baseUrl}/|" />
+						stdWrap.dataWrap = <meta property="og:image" content="{TSFE:baseUrl}|" />
 					}
 				}
 
@@ -173,7 +173,7 @@ config {
 					file.import.data = path:{$plugin.tx_csseo.social.defaultImage}
 					file.height < plugin.tx_csseo.social.openGraph.image.height
 					file.width < plugin.tx_csseo.social.openGraph.image.width
-					stdWrap.dataWrap = <meta property="og:image" content="{TSFE:baseUrl}/|" />
+					stdWrap.dataWrap = <meta property="og:image" content="{TSFE:baseUrl}|" />
 				}
 			}
 
@@ -227,7 +227,7 @@ config {
 						file.import.data = file:current:publicUrl
 						file.height < plugin.tx_csseo.social.twitter.image.height
 						file.width  < plugin.tx_csseo.social.twitter.image.width
-						stdWrap.dataWrap = <meta name="twitter:image" content="{TSFE:baseUrl}/|" />
+						stdWrap.dataWrap = <meta name="twitter:image" content="{TSFE:baseUrl}|" />
 					}
 				}
 
@@ -238,7 +238,7 @@ config {
 					file.import.data = path:{$plugin.tx_csseo.social.twitter.defaultImage} // path:{$plugin.tx_csseo.social.defaultImage}
 					file.height < plugin.tx_csseo.social.twitter.image.height
 					file.width  < plugin.tx_csseo.social.twitter.image.width
-					stdWrap.dataWrap = <meta property="twitter:image" content="{TSFE:baseUrl}/|" />
+					stdWrap.dataWrap = <meta property="twitter:image" content="{TSFE:baseUrl}|" />
 				}
 			}
 		}

--- a/Configuration/TypoScript/Setup/plugin.ts
+++ b/Configuration/TypoScript/Setup/plugin.ts
@@ -68,4 +68,14 @@ Disallow: /*tx_powermail_pi1    # no powermail thanks pages
 Sitemap: |/sitemap.xml
 		)
 	}
+	structureddata {
+		search {
+			enable = {$plugin.tx_csseo.structureddata.search.enable}
+			pid = {$plugin.tx_csseo.structureddata.search.pid}
+			searchtermkey = {$plugin.tx_csseo.structureddata.search.searchtermkey}
+		}
+		breadcrumb {
+			enable = {$plugin.tx_csseo.structureddata.breadcrumb.enable}
+		}
+	}
 }

--- a/Configuration/TypoScript/Setup/structuredData.ts
+++ b/Configuration/TypoScript/Setup/structuredData.ts
@@ -1,0 +1,15 @@
+### SiteSearch ###
+[userFunc = Clickstorm\CsSeo\UserFunc\StructuredData::siteSearch()]
+    page.footerData.655 = USER
+    page.footerData.655.userFunc = Clickstorm\CsSeo\UserFunc\StructuredData->getSiteSearch
+    page.footerData.655.userFunc {
+        pid < plugin.tx_csseo.structureddata.search.pid
+        searchterm < plugin.tx_csseo.structureddata.search.searchtermkey
+    }
+[end]
+
+### Breadcrumb ###
+[userFunc = Clickstorm\CsSeo\UserFunc\StructuredData::breadcrumb()]
+    page.footerData.656 = USER
+    page.footerData.656.userFunc = Clickstorm\CsSeo\UserFunc\StructuredData->getBreadcrumb
+[end]

--- a/Configuration/TypoScript/constants.txt
+++ b/Configuration/TypoScript/constants.txt
@@ -52,6 +52,20 @@ plugin.tx_csseo {
 
     # cat=plugin.tx_csseo/sitemap/3; type=string; label= External sitemap.xml : Full URL to an external sitemap.xml. Further can be defined in the TypoScript setup.
     sitemap.additional =
+
+    # customsubcategory=structureddata=Structured Microdata
+    # cat=plugin.tx_csseo/structureddata/1; type=boolean; label= Enable SiteSearch : Add microdata for sitesearch.
+    structureddata.search.enable =
+
+    # cat=plugin.tx_csseo/structureddata/2; type=int; label= Pid of the search page : Pid of the page, where the searchresults will be displayed
+    structureddata.search.pid = 0
+
+    # cat=plugin.tx_csseo/structureddata/3; type=string; label= Key of variable which represents the searchterm : Name of the variable which carries the searchterms
+    structureddata.search.searchtermkey = searchterm
+
+    # cat=plugin.tx_csseo/structureddata/4; type=boolean; label= Enable Breadcrumb : Add microdata for site breadcrumb.
+    structureddata.breadcrumb.enable =
+
 }
 
 module.tx_csseo_mod1 {

--- a/Configuration/TypoScript/setup.txt
+++ b/Configuration/TypoScript/setup.txt
@@ -4,5 +4,6 @@
 <INCLUDE_TYPOSCRIPT: source="FILE:EXT:cs_seo/Configuration/TypoScript/Setup/module.ts">
 <INCLUDE_TYPOSCRIPT: source="FILE:EXT:cs_seo/Configuration/TypoScript/Setup/meta.ts">
 <INCLUDE_TYPOSCRIPT: source="FILE:EXT:cs_seo/Configuration/TypoScript/Setup/tracking.ts">
+<INCLUDE_TYPOSCRIPT: source="FILE:EXT:cs_seo/Configuration/TypoScript/Setup/structuredData.ts">
 
 <INCLUDE_TYPOSCRIPT: source="DIR:EXT:cs_seo/Configuration/TypoScript/PageTypes/" extensions="ts">


### PR DESCRIPTION
@see https://developers.google.com/search/docs/guides/intro-structured-data

- Added ts-options to enable both (sitesearch and breadcrumb) Independently of each other
- Added Userfunc to add the json-ld data to the footer of the page