### PR TITLE
[BUGFIX] Usage of tmpl->flatSetup prevents page from beeing cachable

### DIFF
--- a/Classes/UserFunc/StructuredData.php
+++ b/Classes/UserFunc/StructuredData.php
@@ -50,18 +50,7 @@ class StructuredData
 
     }
 
-    /**
-     * check if sitesearch is enabled
-     *
-     * @return boolean
-     */
-    public static function siteSearch()
-    {
-        return (!empty($GLOBALS['TSFE']->tmpl->flatSetup['plugin.tx_csseo.structureddata.search.enable']));
-    }
-
-
-    /**
+     /**
      * Returns the json for the siteSearch
      *
      * @return bool|string siteSearch
@@ -103,16 +92,6 @@ class StructuredData
     protected function wrapWithLd($content)
     {
         return '<script type="application/ld+json">'.$content.'</script>';
-    }
-
-    /**
-     * check if breadcrumb is enabled
-     *
-     * @return boolean
-     */
-    public static function breadcrumb()
-    {
-        return (!empty($GLOBALS['TSFE']->tmpl->flatSetup['plugin.tx_csseo.structureddata.breadcrumb.enable']));
     }
 
     /**

--- a/Configuration/TypoScript/Setup/structuredData.ts
+++ b/Configuration/TypoScript/Setup/structuredData.ts
@@ -1,5 +1,5 @@
 ### SiteSearch ###
-[userFunc = Clickstorm\CsSeo\UserFunc\StructuredData::siteSearch()]
+[globalVar = LIT:1 = {$plugin.tx_csseo.structureddata.search.enable}]
     page.footerData.655 = USER
     page.footerData.655.userFunc = Clickstorm\CsSeo\UserFunc\StructuredData->getSiteSearch
     page.footerData.655.userFunc {
@@ -9,7 +9,7 @@
 [end]
 
 ### Breadcrumb ###
-[userFunc = Clickstorm\CsSeo\UserFunc\StructuredData::breadcrumb()]
+[globalVar = LIT:1 = {$plugin.tx_csseo.structureddata.breadcrumb.enable}]
     page.footerData.656 = USER
     page.footerData.656.userFunc = Clickstorm\CsSeo\UserFunc\StructuredData->getBreadcrumb
 [end]


### PR DESCRIPTION
Checking tmpl->flatSetup while rendering the page (and generating hash for caching) returns different values. While rendering the page, flatSetup is not present. While rendering C-Objects, flatSetup is available. So during the complete rendering process, the function returns different values and therefore the page would never ever beeing cachable.

As this functions are used system wide, the complete website would not be cachable.