### PR TITLE
[TASK] Reformat class files according to PSR-2

### DIFF
--- a/Classes/Controller/EvaluationController.php
+++ b/Classes/Controller/EvaluationController.php
@@ -32,23 +32,25 @@ use TYPO3\CMS\Extbase\Mvc\Controller\ActionController;
 
 /**
  * Class EvaluationController
+ *
  * @package Clickstorm\CsSeo\Controller
  */
-class EvaluationController extends ActionController {
+class EvaluationController extends ActionController
+{
 
-	/**
-	 * @var EvaluationRepository
-	 * @inject
-	 */
-	protected $evaluationRepository;
+    /**
+     * @var EvaluationRepository
+     * @inject
+     */
+    protected $evaluationRepository;
 
-	public function showAction($uidForeign, $tableName = 'pages') {
+    public function showAction($uidForeign, $tableName = 'pages')
+    {
 
-		$evaluation = $this->evaluationRepository->findByUidForeignAndTableName($uidForeign, $tableName);
+        $evaluation = $this->evaluationRepository->findByUidForeignAndTableName($uidForeign, $tableName);
 
-		$this->view->assign('results', $evaluation);
+        $this->view->assign('results', $evaluation);
 
-		return $this->view->render();
-	}
-
+        return $this->view->render();
+    }
 }

--- a/Classes/Controller/ModuleController.php
+++ b/Classes/Controller/ModuleController.php
@@ -40,161 +40,171 @@ use TYPO3\CMS\Extbase\Configuration\BackendConfigurationManager;
 
 /**
  * Class ModuleController
+ *
  * @package Clickstorm\CsSeo\Controller
  */
-class ModuleController extends ActionController {
+class ModuleController extends ActionController
+{
 
-	/**
-	 * @var string prefix for session
-	 */
-	const SESSION_PREFIX = 'tx_csseo_';
+    /**
+     * @var string prefix for session
+     */
+    const SESSION_PREFIX = 'tx_csseo_';
 
-	/**
-	 * @var \TYPO3\CMS\Frontend\Page\PageRepository
-	 * @inject
-	 */
-	protected $pageRepository;
+    /**
+     * @var \TYPO3\CMS\Frontend\Page\PageRepository
+     * @inject
+     */
+    protected $pageRepository;
 
-	/**
-	 * @var \Clickstorm\CsSeo\Domain\Repository\EvaluationRepository
-	 * @inject
-	 */
-	protected $evaluationRepository;
+    /**
+     * @var \Clickstorm\CsSeo\Domain\Repository\EvaluationRepository
+     * @inject
+     */
+    protected $evaluationRepository;
 
-	/**
-	 * @var \TYPO3\CMS\Core\DataHandling\DataHandler
-	 */
-	protected $dataHandler;
+    /**
+     * @var \TYPO3\CMS\Core\DataHandling\DataHandler
+     */
+    protected $dataHandler;
 
-	/**
-	 * @var int
-	 */
-	protected $id;
+    /**
+     * @var int
+     */
+    protected $id;
 
-	/**
-	 * @var array
-	 */
-	protected $modParams = ['action' => '','id' => 0, 'lang' => 0, 'depth' => 1, 'table' => 'pages', 'record' => 0];
+    /**
+     * @var array
+     */
+    protected $modParams = ['action' => '', 'id' => 0, 'lang' => 0, 'depth' => 1, 'table' => 'pages', 'record' => 0];
 
-	/**
-	 * @var array
-	 */
-	protected $languages = [];
+    /**
+     * @var array
+     */
+    protected $languages = [];
 
-	/**
-	 * @var bool
-	 */
-	protected $showResults = false;
+    /**
+     * @var bool
+     */
+    protected $showResults = false;
 
-	/**
-	 * Initialize action
-	 *
-	 * @return void
-	 */
-	protected function initializeAction()
-	{
-		// initialize page/be_user TSconfig settings
-		$this->id = (int)GeneralUtility::_GP('id');
-		$this->modSharedTSconfig = BackendUtility::getModTSconfig($this->id, 'mod.SHARED');
-		$this->modTSconfig = BackendUtility::getModTSconfig($this->id, 'mod.' . $this->moduleName);
+    /**
+     * Initialize action
+     *
+     * @return void
+     */
+    protected function initializeAction()
+    {
+        // initialize page/be_user TSconfig settings
+        $this->id = (int)GeneralUtility::_GP('id');
+        $this->modSharedTSconfig = BackendUtility::getModTSconfig($this->id, 'mod.SHARED');
+        $this->modTSconfig = BackendUtility::getModTSconfig($this->id, 'mod.' . $this->moduleName);
 
-		// initialize settings of the module
-		$this->initializeModParams();
-		if(!$this->request->hasArgument('action') && $this->modParams['action']) {
-			$this->request->setArgument('action', $this->modParams['action']);
-			$this->forward($this->modParams['action']);
-		}
+        // initialize settings of the module
+        $this->initializeModParams();
+        if (!$this->request->hasArgument('action') && $this->modParams['action']) {
+            $this->request->setArgument('action', $this->modParams['action']);
+            $this->forward($this->modParams['action']);
+        }
 
-		// get languages
-		$this->languages = $this->getLanguages();
-	}
+        // get languages
+        $this->languages = $this->getLanguages();
+    }
 
-	/**
-	 * initialize the settings for the current view
-	 *
-	 * @throws \TYPO3\CMS\Extbase\Mvc\Exception\NoSuchArgumentException
-	 */
-	protected function initializeModParams() {
-		foreach ($this->modParams as $name => $value) {
-			$this->modParams[$name] = ((int)GeneralUtility::_GP($name) > 0)
-				? (int) GeneralUtility::_GP($name)
-				: $this->getBackendUser()->getSessionData(self::SESSION_PREFIX . $name);
+    /**
+     * initialize the settings for the current view
+     *
+     * @throws \TYPO3\CMS\Extbase\Mvc\Exception\NoSuchArgumentException
+     */
+    protected function initializeModParams()
+    {
+        foreach ($this->modParams as $name => $value) {
+            $this->modParams[$name] = ((int)GeneralUtility::_GP($name) > 0)
+                ? (int)GeneralUtility::_GP($name)
+                : $this->getBackendUser()->getSessionData(self::SESSION_PREFIX . $name);
 
-				if ($this->request->hasArgument($name)) {
-					$arg = $this->request->getArgument($name);
-					$this->modParams[$name] = ($name == 'action' || $name == 'table') ? $arg : (int)$arg;
-				}
-			$this->getBackendUser()->setAndSaveSessionData(self::SESSION_PREFIX . $name, $this->modParams[$name]);
-		}
-	}
+            if ($this->request->hasArgument($name)) {
+                $arg = $this->request->getArgument($name);
+                $this->modParams[$name] = ($name == 'action' || $name == 'table') ? $arg : (int)$arg;
+            }
+            $this->getBackendUser()->setAndSaveSessionData(self::SESSION_PREFIX . $name, $this->modParams[$name]);
+        }
+    }
 
-	/**
-	 * Show SEO fields
-	 */
-	public function pageMetaAction() {
-		$fieldNames = ['title', 'tx_csseo_title', 'tx_csseo_title_only', 'description'];
+    /**
+     * Show SEO fields
+     */
+    public function pageMetaAction()
+    {
+        $fieldNames = ['title', 'tx_csseo_title', 'tx_csseo_title_only', 'description'];
 
-		/** @var TSFEUtility $TSFEUtility */
-		$TSFEUtility =  GeneralUtility::makeInstance(TSFEUtility::class, $this->id, $this->modParams['lang']);
+        /** @var TSFEUtility $TSFEUtility */
+        $TSFEUtility = GeneralUtility::makeInstance(TSFEUtility::class, $this->id, $this->modParams['lang']);
 
-		// preview settings
-		$previewSettings = [];
-		$previewSettings['siteTitle'] = $TSFEUtility->getSiteTitle();
-		$previewSettings['pageTitleFirst'] = $TSFEUtility->getPageTitleFirst();
-		$previewSettings['pageTitleSeparator'] = $TSFEUtility->getPageTitleSeparator();
+        // preview settings
+        $previewSettings = [];
+        $previewSettings['siteTitle'] = $TSFEUtility->getSiteTitle();
+        $previewSettings['pageTitleFirst'] = $TSFEUtility->getPageTitleFirst();
+        $previewSettings['pageTitleSeparator'] = $TSFEUtility->getPageTitleSeparator();
 
-		if($previewSettings['pageTitleFirst']) {
-			$previewSettings['siteTitle'] = $previewSettings['pageTitleSeparator'] . $previewSettings['siteTitle'];
-		} else {
-			$previewSettings['siteTitle'] .= $previewSettings['pageTitleSeparator'];
-		}
-		
-		$this->view->assign('previewSettings', json_encode($previewSettings));
-		
-		$this->processFields($fieldNames);
-	}
+        if ($previewSettings['pageTitleFirst']) {
+            $previewSettings['siteTitle'] = $previewSettings['pageTitleSeparator'] . $previewSettings['siteTitle'];
+        } else {
+            $previewSettings['siteTitle'] .= $previewSettings['pageTitleSeparator'];
+        }
 
-	/**
-	 * Show Open Graph properties
-	 */
-	public function pageIndexAction() {
-		$fieldNames = ['title', 'tx_csseo_canonical', 'tx_csseo_no_index', 'no_search'];
+        $this->view->assign('previewSettings', json_encode($previewSettings));
 
-		$this->processFields($fieldNames);
-	}
+        $this->processFields($fieldNames);
+    }
 
-	/**
-	 * Show Open Graph properties
-	 */
-	public function pageOpenGraphAction() {
-		$fieldNames = ['title', 'tx_csseo_og_title', 'tx_csseo_og_description', 'tx_csseo_og_image'];
+    /**
+     * Show Open Graph properties
+     */
+    public function pageIndexAction()
+    {
+        $fieldNames = ['title', 'tx_csseo_canonical', 'tx_csseo_no_index', 'no_search'];
 
-		$this->processFields($fieldNames);
-	}
+        $this->processFields($fieldNames);
+    }
 
-	/**
-	 * Show Twitter Cards properties
-	 */
-	public function pageTwitterCardsAction() {
-		$fieldNames = ['title', 'tx_csseo_tw_title', 'tx_csseo_tw_description', 'tx_csseo_tw_creator', 'tx_csseo_tw_image'];
+    /**
+     * Show Open Graph properties
+     */
+    public function pageOpenGraphAction()
+    {
+        $fieldNames = ['title', 'tx_csseo_og_title', 'tx_csseo_og_description', 'tx_csseo_og_image'];
 
-		$this->processFields($fieldNames);
-	}
+        $this->processFields($fieldNames);
+    }
 
-	/**
-	 * Show page evaluation results
-	 */
-	public function pageResultsAction() {
-		$fieldNames = ['title', 'tx_csseo_keyword', 'results'];
-		$this->showResults = true;
-		$this->processFields($fieldNames);
-	}
+    /**
+     * Show Twitter Cards properties
+     */
+    public function pageTwitterCardsAction()
+    {
+        $fieldNames =
+            ['title', 'tx_csseo_tw_title', 'tx_csseo_tw_description', 'tx_csseo_tw_creator', 'tx_csseo_tw_image'];
 
-	/**
-	 * Show page evaluation results
-	 */
-	public function pageEvaluationAction() {
-		$page = $this->pageRepository->getPage($this->modParams['id']);
+        $this->processFields($fieldNames);
+    }
+
+    /**
+     * Show page evaluation results
+     */
+    public function pageResultsAction()
+    {
+        $fieldNames = ['title', 'tx_csseo_keyword', 'results'];
+        $this->showResults = true;
+        $this->processFields($fieldNames);
+    }
+
+    /**
+     * Show page evaluation results
+     */
+    public function pageEvaluationAction()
+    {
+        $page = $this->pageRepository->getPage($this->modParams['id']);
         $extKey = 'cs_seo';
         $tables = [
             'pages' => LocalizationUtility::translate($GLOBALS['TCA']['pages']['ctrl']['title'], $extKey)
@@ -202,23 +212,26 @@ class ModuleController extends ActionController {
 
         $tablesToExtend = ConfigurationUtility::getTablesToExtend();
 
-        foreach($tablesToExtend as $tableToExtend) {
-            $tables[$tableToExtend] = LocalizationUtility::translate($GLOBALS['TCA'][$tableToExtend]['ctrl']['title'], $extKey);
+        foreach ($tablesToExtend as $tableToExtend) {
+            $tables[$tableToExtend] =
+                LocalizationUtility::translate($GLOBALS['TCA'][$tableToExtend]['ctrl']['title'], $extKey);
         }
 
         $table = $this->modParams['table'];
-        if($table && $table != 'pages') {
+        if ($table && $table != 'pages') {
             $records = DatabaseUtility::getRecords($table);
             $record = $this->modParams['record'];
-	        $results = $this->getResults($record, $table);
-            $this->view->assignMultiple([
-            	'record' => $record,
-                'records' => $records,
-                'table' => $table
-            ]);
+            $results = $this->getResults($record, $table);
+            $this->view->assignMultiple(
+                [
+                    'record' => $record,
+                    'records' => $records,
+                    'table' => $table
+                ]
+            );
         } else {
             $lang = $this->modParams['lang'];
-            if($lang > 0) {
+            if ($lang > 0) {
                 $page = $this->pageRepository->getPageOverlay($page, $lang);
             }
             $results = $this->getResults($page);
@@ -226,100 +239,110 @@ class ModuleController extends ActionController {
             $this->view->assign('lang', $lang);
         }
 
-		$score = $results['Percentage'];
-		unset($results['Percentage']);
+        $score = $results['Percentage'];
+        unset($results['Percentage']);
 
-		$this->view->assignMultiple([
-			'score' => $score,
-			'results' => $results,
-			'page' => $page,
-            'tables' => $tables,
-			'langDisplay' => $this->languages[$langResult],
-			'languages' => $this->languages
-		]);
-	}
+        $this->view->assignMultiple(
+            [
+                'score' => $score,
+                'results' => $results,
+                'page' => $page,
+                'tables' => $tables,
+                'langDisplay' => $this->languages[$langResult],
+                'languages' => $this->languages
+            ]
+        );
+    }
 
-	/**
-	 * Renders the menu so that it can be returned as response to an AJAX call
-	 *
-	 * @param array $params Array of parameters from the AJAX interface, currently unused
-	 * @param \TYPO3\CMS\Core\Http\AjaxRequestHandler $ajaxObj Object of type AjaxRequestHandler
-	 * @return void
-	 */
-	public function update($params = array(), \TYPO3\CMS\Core\Http\AjaxRequestHandler &$ajaxObj = NULL) {
+    /**
+     * Renders the menu so that it can be returned as response to an AJAX call
+     *
+     * @param array $params Array of parameters from the AJAX interface, currently unused
+     * @param \TYPO3\CMS\Core\Http\AjaxRequestHandler $ajaxObj Object of type AjaxRequestHandler
+     *
+     * @return void
+     */
+    public function update($params = [], \TYPO3\CMS\Core\Http\AjaxRequestHandler &$ajaxObj = null)
+    {
 
-		// get parameter
-		$postdata = file_get_contents("php://input");
-		$attr = json_decode($postdata);
+        // get parameter
+        $postdata = file_get_contents("php://input");
+        $attr = json_decode($postdata);
 
-		// prepare data array
-		$tableName = 'pages';
-		$uid = $attr->entry->uid;
-		$field = $attr->field;
+        // prepare data array
+        $tableName = 'pages';
+        $uid = $attr->entry->uid;
+        $field = $attr->field;
 
-		// check for language overlay
-		if($attr->entry->_PAGES_OVERLAY && isset($GLOBALS['TCA']['pages_language_overlay']['columns'][$field])) {
-			$tableName = 'pages_language_overlay';
-			$uid = $attr->entry->_PAGES_OVERLAY_UID;
-		}
+        // check for language overlay
+        if ($attr->entry->_PAGES_OVERLAY && isset($GLOBALS['TCA']['pages_language_overlay']['columns'][$field])) {
+            $tableName = 'pages_language_overlay';
+            $uid = $attr->entry->_PAGES_OVERLAY_UID;
+        }
 
-		// update map
-		$data[$tableName][$uid][$field] = $attr->value;
+        // update map
+        $data[$tableName][$uid][$field] = $attr->value;
 
-		// update data
-		$dataHandler = $this->getDataHandler();
-		$dataHandler->datamap = $data;
-		$dataHandler->process_datamap();
-		if(!empty($dataHandler->errorLog)) {
-			$ajaxObj->addContent('Error', implode(',', $dataHandler->errorLog));
-		}
-	}
+        // update data
+        $dataHandler = $this->getDataHandler();
+        $dataHandler->datamap = $data;
+        $dataHandler->process_datamap();
+        if (!empty($dataHandler->errorLog)) {
+            $ajaxObj->addContent('Error', implode(',', $dataHandler->errorLog));
+        }
+    }
 
-	/**
-	 * process all fields for the UI grid JSON
-	 * @param $fieldNames
-	 */
-	protected function processFields($fieldNames) {
-		// build the rows
-		if($this->modParams['id'] == 0) {
-			return;
-		}
+    /**
+     * process all fields for the UI grid JSON
+     *
+     * @param $fieldNames
+     */
+    protected function processFields($fieldNames)
+    {
+        // build the rows
+        if ($this->modParams['id'] == 0) {
+            return;
+        }
 
-		// build the columns
-		$columnDefs = [];
-		foreach ($fieldNames as $fieldName) {
-			$columnDefs[] = $this->getColumnDefinition($fieldName);
-		}
+        // build the columns
+        $columnDefs = [];
+        foreach ($fieldNames as $fieldName) {
+            $columnDefs[] = $this->getColumnDefinition($fieldName);
+        }
 
-		// fetch the rows
-		if($this->modParams['lang'] > 0) {
-			$this->pageRepository->sys_language_uid = $this->modParams['lang'];
-			$columnDefs[] = $this->getColumnDefinition('sys_language_uid');
-		}
-		
-		$page = $this->pageRepository->getPage($this->modParams['id']);
-		$rowEntries = $this->getPageTree($page, $this->modParams['depth']);
+        // fetch the rows
+        if ($this->modParams['lang'] > 0) {
+            $this->pageRepository->sys_language_uid = $this->modParams['lang'];
+            $columnDefs[] = $this->getColumnDefinition('sys_language_uid');
+        }
 
-		$this->view->assignMultiple([
-			'pageJSON' => $this->buildGridJSON($rowEntries, $columnDefs),
-			'depth' => $this->modParams['depth'],
-			'lang' => $this->modParams['lang'],
-			'languages' => $this->languages
-		]);
-	}
+        $page = $this->pageRepository->getPage($this->modParams['id']);
+        $rowEntries = $this->getPageTree($page, $this->modParams['depth']);
 
-	/**
-	 * returns the final JSON incl. settings for the UI Grid
-	 *
-	 * @param $rowEntries
-	 * @param $columnDefs
-	 * @return string
-	 */
-	protected function buildGridJSON($rowEntries, $columnDefs) {
-		return '
+        $this->view->assignMultiple(
+            [
+                'pageJSON' => $this->buildGridJSON($rowEntries, $columnDefs),
+                'depth' => $this->modParams['depth'],
+                'lang' => $this->modParams['lang'],
+                'languages' => $this->languages
+            ]
+        );
+    }
+
+    /**
+     * returns the final JSON incl. settings for the UI Grid
+     *
+     * @param $rowEntries
+     * @param $columnDefs
+     *
+     * @return string
+     */
+    protected function buildGridJSON($rowEntries, $columnDefs)
+    {
+        return '
 			{
-				data:' . json_encode($rowEntries) .',
-				columnDefs: [' . implode(',', $columnDefs). '],
+				data:' . json_encode($rowEntries) . ',
+				columnDefs: [' . implode(',', $columnDefs) . '],
 				enableSorting: true,
 				showTreeExpandNoChildren: false,
 				enableGridMenu: true,
@@ -331,205 +354,237 @@ class ModuleController extends ActionController {
 				}
 			}
 		';
-	}
+    }
 
-	/**
-	 * get the UI grid column definition for the current field
-	 * @param $fieldName
-	 * @return mixed
-	 */
-	protected function getColumnDefinition($fieldName) {
-		$columnDef = ['field' => $fieldName];
-		if($fieldName == 'sys_language_uid' || $fieldName == 'results') {
+    /**
+     * get the UI grid column definition for the current field
+     *
+     * @param $fieldName
+     *
+     * @return mixed
+     */
+    protected function getColumnDefinition($fieldName)
+    {
+        $columnDef = ['field' => $fieldName];
+        if ($fieldName == 'sys_language_uid' || $fieldName == 'results') {
+        } else {
+            $columnDef['displayName'] =
+                $this->getLanguageService()->sL($GLOBALS['TCA']['pages']['columns'][$fieldName]['label']);
+            switch ($GLOBALS['TCA']['pages']['columns'][$fieldName]['config']['type']) {
+                case 'check':
+                    $columnDef['type'] = 'boolean';
+                    $columnDef['width'] = 100;
+                    $columnDef['cellTemplate'] =
+                        '<div class="ui-grid-cell-contents ng-binding ng-scope text-center"><span class="glyphicon glyphicon-{{row.entity[col.field] == true ? \'ok\' : \'remove\'}}"></span></div>';
+                    $columnDef['editableCellTemplate'] =
+                        '<div><form name="inputForm" class="text-center"><input type="checkbox" ui-grid-editor ng-model="MODEL_COL_FIELD" ng-click="grid.appScope.currentValue = MODEL_COL_FIELD"></form></div>';
+                    $columnDef['enableFiltering'] = false;
+                    break;
+                case 'inline':
+                    $columnDef['type'] = 'object';
+                    $columnDef['width'] = 100;
+                    $columnDef['enableFiltering'] = false;
+                    break;
+                case 'text':
+                    $columnDef['max'] = $GLOBALS['TCA']['pages']['columns'][$fieldName]['config']['max'];
+                    $columnDef['editableCellTemplate'] =
+                        '<div><form name="inputForm"><textarea class="form-control" ng-maxlength="'
+                        . $columnDef['max']
+                        . '" ui-grid-editor ng-model="MODEL_COL_FIELD" ng-keyup="grid.appScope.currentValue = MODEL_COL_FIELD"></form></div>';
+                    break;
+                default:
+                    $columnDef['max'] = $GLOBALS['TCA']['pages']['columns'][$fieldName]['config']['max'];
+                    $columnDef['editableCellTemplate'] =
+                        '<div><form name="inputForm" ng-model="form"><input type="INPUT_TYPE" class="form-control" ng-maxlength="'
+                        . $columnDef['max']
+                        . '" ui-grid-editor ng-model="MODEL_COL_FIELD" ng-keyup="grid.appScope.currentValue = MODEL_COL_FIELD"></form></div>';
+            }
+        }
 
-		} else {
-			$columnDef['displayName'] = $this->getLanguageService()->sL($GLOBALS['TCA']['pages']['columns'][$fieldName]['label']);
-			switch ($GLOBALS['TCA']['pages']['columns'][$fieldName]['config']['type']) {
-				case 'check':
-					$columnDef['type'] = 'boolean';
-					$columnDef['width'] = 100;
-					$columnDef['cellTemplate'] = '<div class="ui-grid-cell-contents ng-binding ng-scope text-center"><span class="glyphicon glyphicon-{{row.entity[col.field] == true ? \'ok\' : \'remove\'}}"></span></div>';
-					$columnDef['editableCellTemplate'] = '<div><form name="inputForm" class="text-center"><input type="checkbox" ui-grid-editor ng-model="MODEL_COL_FIELD" ng-click="grid.appScope.currentValue = MODEL_COL_FIELD"></form></div>';
-					$columnDef['enableFiltering'] = false;
-					break;
-				case 'inline':
-					$columnDef['type'] = 'object';
-					$columnDef['width'] = 100;
-					$columnDef['enableFiltering'] = false;
-					break;
-				case 'text':
-					$columnDef['max'] = $GLOBALS['TCA']['pages']['columns'][$fieldName]['config']['max'];
-					$columnDef['editableCellTemplate'] = '<div><form name="inputForm"><textarea class="form-control" ng-maxlength="' . $columnDef['max'] . '" ui-grid-editor ng-model="MODEL_COL_FIELD" ng-keyup="grid.appScope.currentValue = MODEL_COL_FIELD"></form></div>';
-					break;
-				default:
-					$columnDef['max'] = $GLOBALS['TCA']['pages']['columns'][$fieldName]['config']['max'];
-					$columnDef['editableCellTemplate'] = '<div><form name="inputForm" ng-model="form"><input type="INPUT_TYPE" class="form-control" ng-maxlength="' . $columnDef['max'] . '" ui-grid-editor ng-model="MODEL_COL_FIELD" ng-keyup="grid.appScope.currentValue = MODEL_COL_FIELD"></form></div>';
-			}
-		}
+        switch ($fieldName) {
+            case 'title':
+                $columnDef['cellTemplate'] =
+                    '<div class="ui-grid-cell-contents ng-binding ng-scope"><span ng-repeat="i in grid.appScope.rangeArray | limitTo: row.entity.level">&nbsp;&nbsp;</span>{{row.entity.title}}</div>';
+                break;
+            case 'tx_csseo_title':
+                $columnDef['min'] = 35;
+                break;
+            case 'description':
+                $columnDef['min'] = 120;
+                break;
+            case 'keyword':
+                $columnDef['nl2separator'] = true;
+                break;
+            case 'sys_language_uid':
+                $columnDef['displayName'] =
+                    $this->getLanguageService()->sL(
+                        $GLOBALS['TCA']['pages_language_overlay']['columns'][$fieldName]['label']
+                    );
+                $columnDef['width'] = 100;
+                $columnDef['type'] = 'object';
+                $columnDef['enableFiltering'] = false;
+                break;
+            case 'results':
+                $columnDef['displayName'] =
+                    $this->getLanguageService()->sL(
+                        $GLOBALS['TCA']['tx_csseo_domain_model_evaluation']['columns'][$fieldName]['label']
+                    );
+                $columnDef['type'] = 'object';
+        }
 
-		switch ($fieldName) {
-			case 'title':
-				$columnDef['cellTemplate'] = '<div class="ui-grid-cell-contents ng-binding ng-scope"><span ng-repeat="i in grid.appScope.rangeArray | limitTo: row.entity.level">&nbsp;&nbsp;</span>{{row.entity.title}}</div>';
-				break;
-			case 'tx_csseo_title':
-				$columnDef['min'] = 35;
-				break;
-			case 'description':
-				$columnDef['min'] = 120;
-				break;
-			case 'keyword':
-				$columnDef['nl2separator'] = true;
-				break;
-			case 'sys_language_uid':
-				$columnDef['displayName'] = $this->getLanguageService()->sL($GLOBALS['TCA']['pages_language_overlay']['columns'][$fieldName]['label']);
-				$columnDef['width'] = 100;
-				$columnDef['type'] = 'object';
-				$columnDef['enableFiltering'] = false;
-				break;
-			case 'results':
-				$columnDef['displayName'] = $this->getLanguageService()->sL($GLOBALS['TCA']['tx_csseo_domain_model_evaluation']['columns'][$fieldName]['label']);
-				$columnDef['type'] = 'object';
-		}
+        return json_encode($columnDef);
+    }
 
-		return json_encode($columnDef);
-	}
+    /**
+     * recursive function for building a page array
+     *
+     * @param array $page the current page
+     * @param int $depth the current depth
+     * @param array $pages contains all pages so far
+     * @param int $level the tree level required for the UI grid
+     *
+     * @return array
+     */
+    protected function getPageTree($page, $depth, $pages = [], $level = 0)
+    {
+        // default query settings
+        $fields = '*';
+        $sortField = 'sorting';
 
-	/**
-	 * recursive function for building a page array
-	 *
-	 * @param array $page the current page
-	 * @param int $depth the current depth
-	 * @param array $pages contains all pages so far
-	 * @param int $level the tree level required for the UI grid
-	 * @return array
-	 */
-	protected function getPageTree($page, $depth, $pages = [], $level = 0){
-		// default query settings
-		$fields = '*';
-		$sortField = 'sorting';
+        // decrease the depth
+        $depth--;
 
-		// decrease the depth
-		$depth--;
+        // add the current language value
+        if ($this->modParams['lang'] > 0) {
+            $page['sys_language_uid'] = $this->languages[$page['_PAGES_OVERLAY_LANGUAGE'] ?: 0];
+        }
 
-		// add the current language value
-		if($this->modParams['lang'] > 0) {
-			$page['sys_language_uid'] = $this->languages[$page['_PAGES_OVERLAY_LANGUAGE']?:0];
-		}
+        if ($this->showResults) {
+            $results = $this->getResults($page);
+            $page['results'] = $results['Percentage']['count'];
+        }
 
-		if($this->showResults) {
-			$results = $this->getResults($page);
-			$page['results'] = $results['Percentage']['count'];
-		}
+        $page['level'] = $level;
 
-		$page['level'] = $level;
+        // add the page to the pages array
+        $pages[] = &$page;
 
-		// add the page to the pages array
-		$pages[] = &$page;
+        // fetch subpages and set the treelevel
+        if ($depth > 0) {
+            $subPages = $this->pageRepository->getMenu($page['uid'], $fields, $sortField);
+            if (count($subPages) > 0) {
+                $page['$$treeLevel'] = $level;
+                $level++;
+                foreach ($subPages as &$subPage) {
+                    $pages = $this->getPageTree($subPage, $depth, $pages, $level);
+                }
+            }
+        }
+        return $pages;
+    }
 
-		// fetch subpages and set the treelevel
-		if($depth > 0) {
-			$subPages = $this->pageRepository->getMenu($page['uid'],$fields,$sortField);
-			if(count($subPages) > 0) {
-				$page['$$treeLevel'] = $level;
-				$level++;
-				foreach ($subPages as &$subPage) {
-					$pages = $this->getPageTree($subPage, $depth, $pages, $level);
-				}
-			}
-		}
-		return $pages;
-	}
-
-	/**
-	 * return evaluation results of a specific page
-	 *
-	 * @param $record
-	 * @param $table
-	 * @return array
-	 */
-	protected function getResults($record, $table = '') {
-		$results = [];
-		if($table) {
-			$evaluation = $this->evaluationRepository->findByUidForeignAndTableName($record, $table);
-		} else {
-			if(isset($record['_PAGES_OVERLAY_LANGUAGE'])) {
-				$evaluation = $this->evaluationRepository->findByUidForeignAndTableName($record['_PAGES_OVERLAY_UID'], 'pages_language_overlay');
-			} else {
-				$evaluation = $this->evaluationRepository->findByUidForeignAndTableName((int)$record['uid'], 'pages');
-			}
-		}
+    /**
+     * return evaluation results of a specific page
+     *
+     * @param $record
+     * @param $table
+     *
+     * @return array
+     */
+    protected function getResults($record, $table = '')
+    {
+        $results = [];
+        if ($table) {
+            $evaluation = $this->evaluationRepository->findByUidForeignAndTableName($record, $table);
+        } else {
+            if (isset($record['_PAGES_OVERLAY_LANGUAGE'])) {
+                $evaluation =
+                    $this->evaluationRepository->findByUidForeignAndTableName(
+                        $record['_PAGES_OVERLAY_UID'],
+                        'pages_language_overlay'
+                    );
+            } else {
+                $evaluation = $this->evaluationRepository->findByUidForeignAndTableName((int)$record['uid'], 'pages');
+            }
+        }
 
 
-		if($evaluation) {
-			$results = $evaluation->getResults();
-		}
-		return $results;
-	}
+        if ($evaluation) {
+            $results = $evaluation->getResults();
+        }
+        return $results;
+    }
 
-	/**
-	 * Returns a SQL query for selecting sys_language records.
-	 *
-	 * @return string Return query string.
-	 */
-	public function getLanguages()
-	{
-		$languages[0] = 'Default';
+    /**
+     * Returns a SQL query for selecting sys_language records.
+     *
+     * @return string Return query string.
+     */
+    public function getLanguages()
+    {
+        $languages[0] = 'Default';
 
-		$res = $this->getDatabaseConnection()->exec_SELECTquery(
-			'sys_language.*',
-			'sys_language',
-			'sys_language.hidden=0',
-			'',
-			'sys_language.title'
-		);
-		while ($lRow = $this->getDatabaseConnection()->sql_fetch_assoc($res)) {
-			if ($this->getBackendUser()->checkLanguageAccess($lRow['uid'])) {
-				$languages[$lRow['uid']] = $lRow['hidden'] ? '(' . $lRow['title'] . ')' : $lRow['title'];
-			}
-		}
-		// Setting alternative default label:
-		if (($this->modSharedTSconfig['properties']['defaultLanguageLabel'] || $this->modTSconfig['properties']['defaultLanguageLabel'])) {
-			$languages[0] = $this->modTSconfig['properties']['defaultLanguageLabel'] ? $this->modTSconfig['properties']['defaultLanguageLabel'] : $this->modSharedTSconfig['properties']['defaultLanguageLabel'];
-		}
-		return $languages;
-	}
+        $res = $this->getDatabaseConnection()->exec_SELECTquery(
+            'sys_language.*',
+            'sys_language',
+            'sys_language.hidden=0',
+            '',
+            'sys_language.title'
+        );
+        while ($lRow = $this->getDatabaseConnection()->sql_fetch_assoc($res)) {
+            if ($this->getBackendUser()->checkLanguageAccess($lRow['uid'])) {
+                $languages[$lRow['uid']] = $lRow['hidden'] ? '(' . $lRow['title'] . ')' : $lRow['title'];
+            }
+        }
+        // Setting alternative default label:
+        if (($this->modSharedTSconfig['properties']['defaultLanguageLabel']
+            || $this->modTSconfig['properties']['defaultLanguageLabel'])
+        ) {
+            $languages[0] =
+                $this->modTSconfig['properties']['defaultLanguageLabel']
+                    ? $this->modTSconfig['properties']['defaultLanguageLabel']
+                    : $this->modSharedTSconfig['properties']['defaultLanguageLabel'];
+        }
+        return $languages;
+    }
 
-	/**
-	 * @return \TYPO3\CMS\Core\DataHandling\DataHandler
-	 */
-	public function getDataHandler()
-	{
-		if (!isset($this->dataHandler)) {
-			$this->dataHandler = GeneralUtility::makeInstance(\TYPO3\CMS\Core\DataHandling\DataHandler::class);
-			$this->dataHandler->start(null,null);
-		}
-		return $this->dataHandler;
-	}
+    /**
+     * @return \TYPO3\CMS\Core\DataHandling\DataHandler
+     */
+    public function getDataHandler()
+    {
+        if (!isset($this->dataHandler)) {
+            $this->dataHandler = GeneralUtility::makeInstance(\TYPO3\CMS\Core\DataHandling\DataHandler::class);
+            $this->dataHandler->start(null, null);
+        }
+        return $this->dataHandler;
+    }
 
-	/**
-	 * Returns the database connection
-	 *
-	 * @return \TYPO3\CMS\Core\Database\DatabaseConnection
-	 */
-	protected function getDatabaseConnection()
-	{
-		return $GLOBALS['TYPO3_DB'];
-	}
+    /**
+     * Returns the database connection
+     *
+     * @return \TYPO3\CMS\Core\Database\DatabaseConnection
+     */
+    protected function getDatabaseConnection()
+    {
+        return $GLOBALS['TYPO3_DB'];
+    }
 
-	/**
-	 * @return \TYPO3\CMS\Core\Authentication\BackendUserAuthentication
-	 */
-	protected function getBackendUser()
-	{
-		return $GLOBALS['BE_USER'];
-	}
+    /**
+     * @return \TYPO3\CMS\Core\Authentication\BackendUserAuthentication
+     */
+    protected function getBackendUser()
+    {
+        return $GLOBALS['BE_USER'];
+    }
 
-	/**
-	 * Returns the language service
-	 * @return LanguageService
-	 */
-	protected function getLanguageService()
-	{
-		return $GLOBALS['LANG'];
-	}
+    /**
+     * Returns the language service
+     *
+     * @return LanguageService
+     */
+    protected function getLanguageService()
+    {
+        return $GLOBALS['LANG'];
+    }
 }

--- a/Classes/Controller/TypoScriptFrontendController.php
+++ b/Classes/Controller/TypoScriptFrontendController.php
@@ -34,6 +34,7 @@ use TYPO3\CMS\Frontend\Page\PageRepository;
 
 /**
  * Class TypoScriptFrontendController
+ *
  * @package Clickstorm\CsSeo\Controller
  */
 class TypoScriptFrontendController extends \TYPO3\CMS\Frontend\Controller\TypoScriptFrontendController
@@ -67,6 +68,7 @@ class TypoScriptFrontendController extends \TYPO3\CMS\Frontend\Controller\TypoSc
      *
      * @param string $reason Reason text
      * @param string $header HTTP header to send
+     *
      * @return void
      */
     public function pageNotFoundAndExit($reason = '', $header = '')
@@ -82,7 +84,7 @@ class TypoScriptFrontendController extends \TYPO3\CMS\Frontend\Controller\TypoSc
      */
     public function setSysPageWhereClause()
     {
-        if($GLOBALS['BE_USER']->workspace > 0) {
+        if ($GLOBALS['BE_USER']->workspace > 0) {
             $this->sys_page->versioningPreview = true;
         }
         $this->sys_page->where_hid_del = '';
@@ -103,7 +105,8 @@ class TypoScriptFrontendController extends \TYPO3\CMS\Frontend\Controller\TypoSc
         $timeTracker->push('fetch_the_id initialize/', '');
         // Initialize the page-select functions.
         $this->sys_page = GeneralUtility::makeInstance(PageRepository::class);
-        $this->sys_page->versioningPreview = $this->fePreview === 2 || (int)$this->workspacePreview || (bool)GeneralUtility::_GP('ADMCMD_view');
+        $this->sys_page->versioningPreview =
+            $this->fePreview === 2 || (int)$this->workspacePreview || (bool)GeneralUtility::_GP('ADMCMD_view');
         $this->sys_page->versioningWorkspaceId = $this->whichWorkspace();
         $this->sys_page->init($this->showHiddenPage);
         // Set the valid usergroups for FE
@@ -165,7 +168,8 @@ class TypoScriptFrontendController extends \TYPO3\CMS\Frontend\Controller\TypoSc
             $this->register['SYS_LASTCHANGED'] = (int)$this->page['SYS_LASTCHANGED'];
         }
         if (is_array($this->TYPO3_CONF_VARS['SC_OPTIONS']['tslib/class.tslib_fe.php']['fetchPageId-PostProcessing'])) {
-            foreach ($this->TYPO3_CONF_VARS['SC_OPTIONS']['tslib/class.tslib_fe.php']['fetchPageId-PostProcessing'] as $functionReference) {
+            foreach ($this->TYPO3_CONF_VARS['SC_OPTIONS']['tslib/class.tslib_fe.php']['fetchPageId-PostProcessing'] as
+                $functionReference) {
                 $parameters = ['parentObject' => $this];
                 GeneralUtility::callUserFunction($functionReference, $parameters, $this);
             }

--- a/Classes/Domain/Model/Evaluation.php
+++ b/Classes/Domain/Model/Evaluation.php
@@ -1,7 +1,6 @@
 <?php
 namespace Clickstorm\CsSeo\Domain\Model;
 
-
 /***************************************************************
  *
  *  Copyright notice
@@ -29,64 +28,71 @@ namespace Clickstorm\CsSeo\Domain\Model;
 
 /**
  * Class Evaluation
+ *
  * @package Clickstorm\CsSeo\Domain\Model
  */
 class Evaluation extends \TYPO3\CMS\Extbase\DomainObject\AbstractEntity
 {
-	/**
-	 * @var string
-	 */
-	protected $results;
+    /**
+     * @var string
+     */
+    protected $results;
 
-	/**
-	 * @var int
-	 */
-	protected $uidForeign;
+    /**
+     * @var int
+     */
+    protected $uidForeign;
 
-	/**
-	 * @var string
-	 */
-	protected $tablenames;
+    /**
+     * @var string
+     */
+    protected $tablenames;
 
-	/**
-	 * @return array
-	 */
-	public function getResults() {
-		return unserialize($this->results);
-	}
+    /**
+     * @return array
+     */
+    public function getResults()
+    {
+        return unserialize($this->results);
+    }
 
-	/**
-	 * @param array $results
-	 */
-	public function setResults($results) {
-		$this->results = serialize($results);
-	}
+    /**
+     * @param array $results
+     */
+    public function setResults($results)
+    {
+        $this->results = serialize($results);
+    }
 
-	/**
-	 * @return int
-	 */
-	public function getUidForeign() {
-		return $this->uidForeign;
-	}
+    /**
+     * @return int
+     */
+    public function getUidForeign()
+    {
+        return $this->uidForeign;
+    }
 
-	/**
-	 * @param int $uidForeign
-	 */
-	public function setUidForeign($uidForeign) {
-		$this->uidForeign = $uidForeign;
-	}
+    /**
+     * @param int $uidForeign
+     */
+    public function setUidForeign($uidForeign)
+    {
+        $this->uidForeign = $uidForeign;
+    }
 
-	/**
-	 * @return string
-	 */
-	public function getTablenames() {
-		return $this->tablenames;
-	}
+    /**
+     * @return string
+     */
+    public function getTablenames()
+    {
+        return $this->tablenames;
+    }
 
-	/**
-	 * @param string $tablenames
-	 */
-	public function setTablenames($tablenames) {
-		$this->tablenames = $tablenames;
-	}
+    /**
+     * @param string $tablenames
+     */
+    public function setTablenames($tablenames)
+    {
+        $this->tablenames = $tablenames;
+    }
 }

--- a/Classes/Domain/Repository/EvaluationRepository.php
+++ b/Classes/Domain/Repository/EvaluationRepository.php
@@ -1,7 +1,6 @@
 <?php
 namespace Clickstorm\CsSeo\Domain\Repository;
 
-
 /***************************************************************
  *
  *  Copyright notice
@@ -31,39 +30,43 @@ use TYPO3\CMS\Extbase\Persistence\Generic\Typo3QuerySettings;
 
 /**
  * Class EvaluationRepository
+ *
  * @package Clickstorm\CsSeo\Domain\Repository
  */
 class EvaluationRepository extends \TYPO3\CMS\Extbase\Persistence\Repository
 {
 
-	protected $respectStoragePage = false;
+    protected $respectStoragePage = false;
 
-	public function initializeObject() {
-		/** @var Typo3QuerySettings $defaultQuerySettings */
-		$defaultQuerySettings = $this->objectManager->get(Typo3QuerySettings::class);
-		$defaultQuerySettings->setRespectStoragePage(false);
-		$defaultQuerySettings->setRespectSysLanguage(false);
-		$this->setDefaultQuerySettings($defaultQuerySettings);
-	}
+    public function initializeObject()
+    {
+        /** @var Typo3QuerySettings $defaultQuerySettings */
+        $defaultQuerySettings = $this->objectManager->get(Typo3QuerySettings::class);
+        $defaultQuerySettings->setRespectStoragePage(false);
+        $defaultQuerySettings->setRespectSysLanguage(false);
+        $this->setDefaultQuerySettings($defaultQuerySettings);
+    }
 
-	/**
-	 * Finds an object matching the given identifier.
-	 *
-	 * @param int $uidForeign
-	 * @param string $tableName
-	 * @return object The matching object if found, otherwise NULL
-	*/
-	public function findByUidForeignAndTableName($uidForeign, $tableName) {
+    /**
+     * Finds an object matching the given identifier.
+     *
+     * @param int $uidForeign
+     * @param string $tableName
+     *
+     * @return object The matching object if found, otherwise NULL
+     */
+    public function findByUidForeignAndTableName($uidForeign, $tableName)
+    {
 
-		$query = $this->createQuery();
+        $query = $this->createQuery();
 
-		$constraints = [];
+        $constraints = [];
 
-		$constraints[] = $query->equals('uid_foreign', $uidForeign);
-		$constraints[] = $query->equals('tablenames', $tableName);
+        $constraints[] = $query->equals('uid_foreign', $uidForeign);
+        $constraints[] = $query->equals('tablenames', $tableName);
 
-		$query->matching($query->logicalAnd($constraints));
+        $query->matching($query->logicalAnd($constraints));
 
-		return $query->execute()->getFirst();
-	}
+        return $query->execute()->getFirst();
+    }
 }

--- a/Classes/Evaluation/AbstractEvaluator.php
+++ b/Classes/Evaluation/AbstractEvaluator.php
@@ -29,117 +29,128 @@ use Clickstorm\CsSeo\Utility\ConfigurationUtility;
 
 /**
  * Class AbstractEvaluator
+ *
  * @package Clickstorm\CsSeo\Evaluation
  */
 abstract class AbstractEvaluator implements EvaluationInterface
 {
 
-	const STATE_GREEN = 2;
-	const STATE_YELLOW = 1;
-	const STATE_RED = 0;
+    const STATE_GREEN = 2;
+    const STATE_YELLOW = 1;
+    const STATE_RED = 0;
 
-	/**
-	 * @var \DOMDocument
-	 */
-	protected $domDocument;
+    /**
+     * @var \DOMDocument
+     */
+    protected $domDocument;
 
-	/**
-	 * @var string
-	 */
-	protected $keyword;
+    /**
+     * @var string
+     */
+    protected $keyword;
 
-	/**
-	 * @var string
-	 */
-	protected $bodyContent = '';
+    /**
+     * @var string
+     */
+    protected $bodyContent = '';
 
-	/**
-	 * TSFEUtility constructor.
-	 * @param \DOMDocument $domDocument
-	 * @param string $keyword
-	 */
+    /**
+     * TSFEUtility constructor.
+     *
+     * @param \DOMDocument $domDocument
+     * @param string $keyword
+     */
     public function __construct($domDocument, $keyword = '')
     {
-	    $this->domDocument = $domDocument;
-	    $this->setKeyword($keyword);
-
+        $this->domDocument = $domDocument;
+        $this->setKeyword($keyword);
     }
 
-	/**
-	 * @return \DOMDocument
-	 */
-	public function getDomDocument() {
-		return $this->domDocument;
-	}
+    /**
+     * @return \DOMDocument
+     */
+    public function getDomDocument()
+    {
+        return $this->domDocument;
+    }
 
-	/**
-	 * @param \DOMDocument $domDocument
-	 */
-	public function setDomDocument($domDocument) {
-		$this->domDocument = $domDocument;
-	}
+    /**
+     * @param \DOMDocument $domDocument
+     */
+    public function setDomDocument($domDocument)
+    {
+        $this->domDocument = $domDocument;
+    }
 
-	/**
-	 * @return string
-	 */
-	public function getKeyword() {
-		return $this->keyword;
-	}
+    /**
+     * @return string
+     */
+    public function getKeyword()
+    {
+        return $this->keyword;
+    }
 
-	/**
-	 * @param string $keyword
-	 */
-	public function setKeyword($keyword) {
-		$this->keyword = strtolower($keyword);
-	}
+    /**
+     * @param string $keyword
+     */
+    public function setKeyword($keyword)
+    {
+        $this->keyword = strtolower($keyword);
+    }
 
-	/**
-	 * @param string $tagName
-	 * @return string
-	 */
-	protected function getSingleDomElementContentByTagName($tagName) {
-		$elements = $this->domDocument->getElementsByTagName($tagName);
-		if($elements->item(0)) {
-			return $elements->item(0)->textContent;
-		} else {
-			return '';
-		}
-	}
+    /**
+     * @param string $tagName
+     *
+     * @return string
+     */
+    protected function getSingleDomElementContentByTagName($tagName)
+    {
+        $elements = $this->domDocument->getElementsByTagName($tagName);
+        if ($elements->item(0)) {
+            return $elements->item(0)->textContent;
+        } else {
+            return '';
+        }
+    }
 
-	/**
-	 * @param $metaName
-	 * @return int
-	 */
-	protected function getNumberOfMetaTags($metaName) {
-		$counter = 0;
-		$metaTags = $this->domDocument->getElementsByTagName('meta');
+    /**
+     * @param $metaName
+     *
+     * @return int
+     */
+    protected function getNumberOfMetaTags($metaName)
+    {
+        $counter = 0;
+        $metaTags = $this->domDocument->getElementsByTagName('meta');
 
-		/** @var \DOMElement $metaTag */
-		foreach ($metaTags as $metaTag) {
-			if($metaTag->getAttribute('name') == $metaName) {
-				$counter++;
-			}
-		}
+        /** @var \DOMElement $metaTag */
+        foreach ($metaTags as $metaTag) {
+            if ($metaTag->getAttribute('name') == $metaName) {
+                $counter++;
+            }
+        }
 
-		return $counter;
-	}
+        return $counter;
+    }
 
-	protected function getMetaTagContent($metaName) {
-		$content = '';
-		$metaTags = $this->domDocument->getElementsByTagName('meta');
+    protected function getMetaTagContent($metaName)
+    {
+        $content = '';
+        $metaTags = $this->domDocument->getElementsByTagName('meta');
 
-		/** @var \DOMElement $metaTag */
-		foreach ($metaTags as $metaTag) {
-			if($metaTag->getAttribute('name') == $metaName) {
-				$content = $metaTag->getAttribute('content');
-				break;
-			}
-		}
+        /** @var \DOMElement $metaTag */
+        foreach ($metaTags as $metaTag) {
+            if ($metaTag->getAttribute('name') == $metaName) {
+                $content = $metaTag->getAttribute('content');
+                break;
+            }
+        }
 
-		return $content;
-	}
+        return $content;
+    }
 
-	public function validate() {
-		return [];
-	}
+    public function validate()
+    {
+        return [];
+    }
 }

--- a/Classes/Evaluation/AbstractLengthEvaluator.php
+++ b/Classes/Evaluation/AbstractLengthEvaluator.php
@@ -30,34 +30,37 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 /**
  * Class AbstractLengthEvaluator
+ *
  * @package Clickstorm\CsSeo\Evaluation
  */
 abstract class AbstractLengthEvaluator extends AbstractEvaluator
 {
-	/**
-	 * @param string $content
-	 * @param int $min
-	 * @param int $max
-	 * @return array
-	 */
-	protected function evaluateLength($content, $min, $max) {
-		$state = self::STATE_RED;
+    /**
+     * @param string $content
+     * @param int $min
+     * @param int $max
+     *
+     * @return array
+     */
+    protected function evaluateLength($content, $min, $max)
+    {
+        $state = self::STATE_RED;
 
-		/** @var CharsetConverter $charsetConverter */
-		$charsetConverter = GeneralUtility::makeInstance(CharsetConverter::class);
-		$count = $charsetConverter->strlen('utf-8', $content);
+        /** @var CharsetConverter $charsetConverter */
+        $charsetConverter = GeneralUtility::makeInstance(CharsetConverter::class);
+        $count = $charsetConverter->strlen('utf-8', $content);
 
-		if($count >= $min && $count <= $max) {
-			$state =  self::STATE_GREEN;
-		} else {
-			if($count > 0) {
-				$state =  self::STATE_YELLOW;
-			}
-		}
+        if ($count >= $min && $count <= $max) {
+            $state = self::STATE_GREEN;
+        } else {
+            if ($count > 0) {
+                $state = self::STATE_YELLOW;
+            }
+        }
 
-		return [
-			'state' => $state,
-			'count' => $count
-		];
-	}
+        return [
+            'state' => $state,
+            'count' => $count
+        ];
+    }
 }

--- a/Classes/Evaluation/DescriptionEvaluator.php
+++ b/Classes/Evaluation/DescriptionEvaluator.php
@@ -29,18 +29,19 @@ use Clickstorm\CsSeo\Utility\ConfigurationUtility;
 
 /**
  * Class DescriptionEvaluator
+ *
  * @package Clickstorm\CsSeo\Evaluation
  */
 class DescriptionEvaluator extends AbstractLengthEvaluator
 {
-	/**
-	 * @return array
-	 */
-	public function evaluate() {
-		$extConf = ConfigurationUtility::getEmConfiguration();
+    /**
+     * @return array
+     */
+    public function evaluate()
+    {
+        $extConf = ConfigurationUtility::getEmConfiguration();
 
-		$description = $this->getMetaTagContent('description');
-		return $this->evaluateLength($description, $extConf['minDescription'], $extConf['maxDescription']);
-	}
-
+        $description = $this->getMetaTagContent('description');
+        return $this->evaluateLength($description, $extConf['minDescription'], $extConf['maxDescription']);
+    }
 }

--- a/Classes/Evaluation/EvaluationInterface.php
+++ b/Classes/Evaluation/EvaluationInterface.php
@@ -28,15 +28,17 @@ namespace Clickstorm\CsSeo\Evaluation;
 
 /**
  * Interface EvaluationInterface
+ *
  * @package Clickstorm\CsSeo\Evaluation
  */
-interface EvaluationInterface {
+interface EvaluationInterface
+{
 
-	/**
-	 * Evaluate the html to a specific function
-	 *
-	 * @return array
-	 * @api
-	 */
-	public function evaluate();
+    /**
+     * Evaluate the html to a specific function
+     *
+     * @return array
+     * @api
+     */
+    public function evaluate();
 }

--- a/Classes/Evaluation/H1Evaluator.php
+++ b/Classes/Evaluation/H1Evaluator.php
@@ -28,26 +28,27 @@ namespace Clickstorm\CsSeo\Evaluation;
 
 /**
  * Class H1Evaluator
+ *
  * @package Clickstorm\CsSeo\Evaluation
  */
 class H1Evaluator extends AbstractEvaluator
 {
-	/**
-	 * @return array
-	 */
-	public function evaluate() {
-		$state = self::STATE_RED;
+    /**
+     * @return array
+     */
+    public function evaluate()
+    {
+        $state = self::STATE_RED;
 
-		$count = $this->domDocument->getElementsByTagName('h1')->length;
+        $count = $this->domDocument->getElementsByTagName('h1')->length;
 
-		if($count > 0 && $count < 2) {
-			$state =  self::STATE_GREEN;
-		}
+        if ($count > 0 && $count < 2) {
+            $state = self::STATE_GREEN;
+        }
 
-		return [
-			'count' => $count,
-			'state' => $state
-		];
-	}
-
+        return [
+            'count' => $count,
+            'state' => $state
+        ];
+    }
 }

--- a/Classes/Evaluation/H2Evaluator.php
+++ b/Classes/Evaluation/H2Evaluator.php
@@ -29,28 +29,29 @@ use Clickstorm\CsSeo\Utility\ConfigurationUtility;
 
 /**
  * Class H2Evaluator
+ *
  * @package Clickstorm\CsSeo\Evaluation
  */
 class H2Evaluator extends AbstractEvaluator
 {
 
-	public function evaluate() {
-		$state = self::STATE_RED;
-		$extConf = ConfigurationUtility::getEmConfiguration();
-		$maxH2 = $extConf['maxH2'];
+    public function evaluate()
+    {
+        $state = self::STATE_RED;
+        $extConf = ConfigurationUtility::getEmConfiguration();
+        $maxH2 = $extConf['maxH2'];
 
-		$count = $this->domDocument->getElementsByTagName('h2')->length;
+        $count = $this->domDocument->getElementsByTagName('h2')->length;
 
-		if($count > 0 && $count <= $maxH2) {
-			$state =  self::STATE_GREEN;
-		} elseif ($count > $maxH2) {
-			$state = self::STATE_YELLOW;
-		}
+        if ($count > 0 && $count <= $maxH2) {
+            $state = self::STATE_GREEN;
+        } elseif ($count > $maxH2) {
+            $state = self::STATE_YELLOW;
+        }
 
-		return [
-			'count' => $count,
-			'state' => $state
-		];
-	}
-
+        return [
+            'count' => $count,
+            'state' => $state
+        ];
+    }
 }

--- a/Classes/Evaluation/ImagesEvaluator.php
+++ b/Classes/Evaluation/ImagesEvaluator.php
@@ -28,41 +28,42 @@ namespace Clickstorm\CsSeo\Evaluation;
 
 /**
  * Class ImagesEvaluator
+ *
  * @package Clickstorm\CsSeo\Evaluation
  */
 class ImagesEvaluator extends AbstractEvaluator
 {
 
-	public function evaluate() {
-		$state = self::STATE_RED;
+    public function evaluate()
+    {
+        $state = self::STATE_RED;
 
-		$images = $this->domDocument->getElementsByTagName('img');
-		$count = $images->length;
+        $images = $this->domDocument->getElementsByTagName('img');
+        $count = $images->length;
 
-		$altCount = 0;
+        $altCount = 0;
 
-		/** @var \DOMElement $element */
-		foreach ($images as $element) {
-			$alt = $element->getAttribute('alt');
-			if(!empty($alt)) {
-				$altCount++;
-			}
-		}
+        /** @var \DOMElement $element */
+        foreach ($images as $element) {
+            $alt = $element->getAttribute('alt');
+            if (!empty($alt)) {
+                $altCount++;
+            }
+        }
 
-		if($count == $altCount) {
-			$state = self::STATE_GREEN;
-		} else {
-			if($altCount > 0) {
-				$state = self::STATE_YELLOW;
-			}
-		}
+        if ($count == $altCount) {
+            $state = self::STATE_GREEN;
+        } else {
+            if ($altCount > 0) {
+                $state = self::STATE_YELLOW;
+            }
+        }
 
-		return [
-			'count' => $count,
-			'altCount' => $altCount,
-			'countWithoutAlt' => $count - $altCount,
-			'state' => $state
-		];
-	}
-
+        return [
+            'count' => $count,
+            'altCount' => $altCount,
+            'countWithoutAlt' => $count - $altCount,
+            'state' => $state
+        ];
+    }
 }

--- a/Classes/Evaluation/KeywordEvaluator.php
+++ b/Classes/Evaluation/KeywordEvaluator.php
@@ -29,47 +29,50 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 /**
  * Class KeywordEvaluator
+ *
  * @package Clickstorm\CsSeo\Evaluation
  */
-class KeywordEvaluator extends AbstractEvaluator {
+class KeywordEvaluator extends AbstractEvaluator
+{
 
-	public function evaluate() {
-		$results = [];
+    public function evaluate()
+    {
+        $results = [];
 
-		$state = self::STATE_RED;
+        $state = self::STATE_RED;
 
-		if (empty($this->keyword)) {
-			$results['notSet'] = 1;
-		} else {
-			$contains = ['title' => 0, 'description' => 0, 'body' => 0];
+        if (empty($this->keyword)) {
+            $results['notSet'] = 1;
+        } else {
+            $contains = ['title' => 0, 'description' => 0, 'body' => 0];
 
-			$keywords = GeneralUtility::trimExplode(',', $this->keyword);
+            $keywords = GeneralUtility::trimExplode(',', $this->keyword);
 
-			foreach ($keywords as $keyword) {
-				$contains['title'] += substr_count(
-					strtolower($this->getSingleDomElementContentByTagName('title')),
-					$keyword
-				);
-				$contains['description'] += substr_count(
-					strtolower($this->getMetaTagContent('description')),
-					$keyword
-				);
-				$contains['body'] += substr_count(
-					strtolower($this->getSingleDomElementContentByTagName('body')),
-					$keyword
-				);
-			}
+            foreach ($keywords as $keyword) {
+                $contains['title'] += substr_count(
+                    strtolower($this->getSingleDomElementContentByTagName('title')),
+                    $keyword
+                );
+                $contains['description'] += substr_count(
+                    strtolower($this->getMetaTagContent('description')),
+                    $keyword
+                );
+                $contains['body'] += substr_count(
+                    strtolower($this->getSingleDomElementContentByTagName('body')),
+                    $keyword
+                );
+            }
 
-			if ($contains['title'] > 0 && $contains['description'] > 0 && $contains['body'] > 0) {
-				$state = self::STATE_GREEN;
-			} else {
-				$state = self::STATE_YELLOW;
-			}
-			$results['contains'] = $contains;
-		}
+            if ($contains['title'] > 0 && $contains['description'] > 0 && $contains['body'] > 0) {
+                $state = self::STATE_GREEN;
+            } else {
+                $state = self::STATE_YELLOW;
+            }
+            $results['contains'] = $contains;
+        }
 
-		$results['state'] = $state;
+        $results['state'] = $state;
 
-		return $results;
-	}
+        return $results;
+    }
 }

--- a/Classes/Evaluation/TCA/RobotsDisallowAllEvaluator.php
+++ b/Classes/Evaluation/TCA/RobotsDisallowAllEvaluator.php
@@ -31,61 +31,67 @@ use \TYPO3\CMS\Core\Utility\GeneralUtility;
 
 /**
  * Class RobotsEvaluator
+ *
  * @package Clickstorm\CsSeo\Evaluation
  */
-class RobotsDisallowAllEvaluator {
-	/**
-	 * Server-side validation/evaluation on saving the record
-	 *
-	 * @param string $value The field value to be evaluated
-	 * @param string $is_in The "is_in" value of the field configuration from TCA
-	 * @param bool $set Boolean defining if the value is written to the database or not. Must be passed by reference and changed if needed.
-	 * @return string Evaluated field value
-	 */
-	public function evaluateFieldValue($value, $is_in, &$set) {
-		if ($this->isRobotsDisallowed($value)) {
-			/** @var \TYPO3\CMS\Core\Messaging\FlashMessage $flashMessage */
-			$flashMessage = GeneralUtility::makeInstance(
-				FlashMessage::class,
-				$GLOBALS['LANG']->sL(
-					'LLL:EXT:cs_seo/Resources/Private/Language/locallang_db.xlf:evaluation.tca.robots_txt.robots_disallow_all'
-				),
-				"",
-				FlashMessage::WARNING
-			);
-			/** @var $flashMessageService \TYPO3\CMS\Core\Messaging\FlashMessageService */
-			$flashMessageService = GeneralUtility::makeInstance(FlashMessageService::class);
-			/** @var $defaultFlashMessageQueue \TYPO3\CMS\Core\Messaging\FlashMessageQueue */
-			$defaultFlashMessageQueue = $flashMessageService->getMessageQueueByIdentifier();
-			$defaultFlashMessageQueue->enqueue($flashMessage);
-		}
+class RobotsDisallowAllEvaluator
+{
+    /**
+     * Server-side validation/evaluation on saving the record
+     *
+     * @param string $value The field value to be evaluated
+     * @param string $is_in The "is_in" value of the field configuration from TCA
+     * @param bool $set Boolean defining if the value is written to the database or not. Must be passed by reference
+     *     and changed if needed.
+     *
+     * @return string Evaluated field value
+     */
+    public function evaluateFieldValue($value, $is_in, &$set)
+    {
+        if ($this->isRobotsDisallowed($value)) {
+            /** @var \TYPO3\CMS\Core\Messaging\FlashMessage $flashMessage */
+            $flashMessage = GeneralUtility::makeInstance(
+                FlashMessage::class,
+                $GLOBALS['LANG']->sL(
+                    'LLL:EXT:cs_seo/Resources/Private/Language/locallang_db.xlf:evaluation.tca.robots_txt.robots_disallow_all'
+                ),
+                "",
+                FlashMessage::WARNING
+            );
+            /** @var $flashMessageService \TYPO3\CMS\Core\Messaging\FlashMessageService */
+            $flashMessageService = GeneralUtility::makeInstance(FlashMessageService::class);
+            /** @var $defaultFlashMessageQueue \TYPO3\CMS\Core\Messaging\FlashMessageQueue */
+            $defaultFlashMessageQueue = $flashMessageService->getMessageQueueByIdentifier();
+            $defaultFlashMessageQueue->enqueue($flashMessage);
+        }
 
-		return $value;
-	}
+        return $value;
+    }
 
-	/**
-	 * Check if somebody made a disallow: / Statement
-	 *
-	 * @param string $value The field value to be evaluated
-	 * @return bool
-	 */
-	protected function isRobotsDisallowed($value) {
-		$disallowed = false;
-		// case-insensitive
-		// disallow:[0-x Leerzeichen]/
+    /**
+     * Check if somebody made a disallow: / Statement
+     *
+     * @param string $value The field value to be evaluated
+     *
+     * @return bool
+     */
+    protected function isRobotsDisallowed($value)
+    {
+        $disallowed = false;
+        // case-insensitive
+        // disallow:[0-x Leerzeichen]/
 
-		// preg:
-		// "disallow:"
-		// "\h*" horizontal whitespace (0 or more times)
-		// "/"
-		// "\h+" horizontal whitespace (0 or more times)
-		// "\R" end of line
-		// "/$" linebreak
-		if (preg_match("~Disallow:\h*(/\h+|/\R|/$)~i", $value)) {
-			$disallowed = true;
-		}
+        // preg:
+        // "disallow:"
+        // "\h*" horizontal whitespace (0 or more times)
+        // "/"
+        // "\h+" horizontal whitespace (0 or more times)
+        // "\R" end of line
+        // "/$" linebreak
+        if (preg_match("~Disallow:\h*(/\h+|/\R|/$)~i", $value)) {
+            $disallowed = true;
+        }
 
-		return $disallowed;
-	}
-
+        return $disallowed;
+    }
 }

--- a/Classes/Evaluation/TCA/RobotsExistsEvaluator.php
+++ b/Classes/Evaluation/TCA/RobotsExistsEvaluator.php
@@ -32,35 +32,40 @@ use \TYPO3\CMS\Core\Utility\GeneralUtility;
 
 /**
  * Class RobotsEvaluator
+ *
  * @package Clickstorm\CsSeo\Evaluation
  */
-class RobotsExistsEvaluator {
-	/**
-	 * Server-side validation/evaluation on saving the record
-	 *
-	 * @param string $value The field value to be evaluated
-	 * @param string $is_in The "is_in" value of the field configuration from TCA
-	 * @param bool $set Boolean defining if the value is written to the database or not. Must be passed by reference and changed if needed.
-	 * @return string Evaluated field value
-	 */
-	public function evaluateFieldValue($value, $is_in, &$set) {
-		if (file_exists(PATH_site . 'robots.txt') && strlen($value) > 0) {
-			/** @var \TYPO3\CMS\Core\Messaging\FlashMessage $flashMessage */
-			$flashMessage = GeneralUtility::makeInstance(
-				FlashMessage::class,
-				$GLOBALS['LANG']->sL(
-					'LLL:EXT:cs_seo/Resources/Private/Language/locallang_db.xlf:evaluation.tca.robots_txt.robots_exists'
-				),
-				"",
-				FlashMessage::WARNING
-			);
-			/** @var $flashMessageService \TYPO3\CMS\Core\Messaging\FlashMessageService */
-			$flashMessageService = GeneralUtility::makeInstance(FlashMessageService::class);
-			/** @var $defaultFlashMessageQueue \TYPO3\CMS\Core\Messaging\FlashMessageQueue */
-			$defaultFlashMessageQueue = $flashMessageService->getMessageQueueByIdentifier();
-			$defaultFlashMessageQueue->enqueue($flashMessage);
-		}
+class RobotsExistsEvaluator
+{
+    /**
+     * Server-side validation/evaluation on saving the record
+     *
+     * @param string $value The field value to be evaluated
+     * @param string $is_in The "is_in" value of the field configuration from TCA
+     * @param bool $set Boolean defining if the value is written to the database or not. Must be passed by reference
+     *     and changed if needed.
+     *
+     * @return string Evaluated field value
+     */
+    public function evaluateFieldValue($value, $is_in, &$set)
+    {
+        if (file_exists(PATH_site . 'robots.txt') && strlen($value) > 0) {
+            /** @var \TYPO3\CMS\Core\Messaging\FlashMessage $flashMessage */
+            $flashMessage = GeneralUtility::makeInstance(
+                FlashMessage::class,
+                $GLOBALS['LANG']->sL(
+                    'LLL:EXT:cs_seo/Resources/Private/Language/locallang_db.xlf:evaluation.tca.robots_txt.robots_exists'
+                ),
+                "",
+                FlashMessage::WARNING
+            );
+            /** @var $flashMessageService \TYPO3\CMS\Core\Messaging\FlashMessageService */
+            $flashMessageService = GeneralUtility::makeInstance(FlashMessageService::class);
+            /** @var $defaultFlashMessageQueue \TYPO3\CMS\Core\Messaging\FlashMessageQueue */
+            $defaultFlashMessageQueue = $flashMessageService->getMessageQueueByIdentifier();
+            $defaultFlashMessageQueue->enqueue($flashMessage);
+        }
 
-		return $value;
-	}
+        return $value;
+    }
 }

--- a/Classes/Evaluation/TitleEvaluator.php
+++ b/Classes/Evaluation/TitleEvaluator.php
@@ -29,14 +29,16 @@ use Clickstorm\CsSeo\Utility\ConfigurationUtility;
 
 /**
  * Class TitleEvaluator
+ *
  * @package Clickstorm\CsSeo\Evaluation
  */
 class TitleEvaluator extends AbstractLengthEvaluator
 {
-	public function evaluate() {
-		$title = $this->getSingleDomElementContentByTagName('title');
-		$extConf = ConfigurationUtility::getEmConfiguration();
+    public function evaluate()
+    {
+        $title = $this->getSingleDomElementContentByTagName('title');
+        $extConf = ConfigurationUtility::getEmConfiguration();
 
-		return $this->evaluateLength($title, $extConf['minTitle'], $extConf['maxTitle']);
-	}
+        return $this->evaluateLength($title, $extConf['minTitle'], $extConf['maxTitle']);
+    }
 }

--- a/Classes/Hook/PageHook.php
+++ b/Classes/Hook/PageHook.php
@@ -41,194 +41,220 @@ use TYPO3\CMS\Extbase\Configuration\ConfigurationManagerInterface;
  * hook to display the evaluation results in the page module
  *
  * Class pageHook
+ *
  * @package Clickstorm\CsSeo\Hook
  */
-class PageHook {
+class PageHook
+{
 
-	/**
-	 * @var StandaloneView
-	 */
-	protected $view;
+    /**
+     * @var StandaloneView
+     */
+    protected $view;
 
-	/**
-	 * @var string $resourcesPath
-	 */
-	protected $resourcesPath;
+    /**
+     * @var string $resourcesPath
+     */
+    protected $resourcesPath;
 
-	public function __construct() {
-		$this->resourcesPath = ExtensionManagementUtility::extRelPath('cs_seo') . 'Resources/';
-	}
+    public function __construct()
+    {
+        $this->resourcesPath = ExtensionManagementUtility::extRelPath('cs_seo') . 'Resources/';
+    }
 
-	/**
-	 * Load the necessary css
-	 *
-	 * This will only be done when the referenced record is available
-	 *
-	 * @return void
-	 */
-	protected function loadCss()
-	{
-		// @todo Set to TRUE when finished
-		$compress = false;
-		$cssFiles = array(
-			'Icons.css',
-			'Evaluation.css'
-		);
+    /**
+     * Load the necessary css
+     *
+     * This will only be done when the referenced record is available
+     *
+     * @return void
+     */
+    protected function loadCss()
+    {
+        // @todo Set to TRUE when finished
+        $compress = false;
+        $cssFiles = [
+            'Icons.css',
+            'Evaluation.css'
+        ];
 
-		$baseUrl = $this->resourcesPath . 'Public/CSS/';
+        $baseUrl = $this->resourcesPath . 'Public/CSS/';
 
-		// Load the wizards css
-		foreach ($cssFiles as $cssFile) {
-			$this->getPageRenderer()->addCssFile($baseUrl . $cssFile, 'stylesheet', 'all', '', $compress, false);
-		}
-	}
+        // Load the wizards css
+        foreach ($cssFiles as $cssFile) {
+            $this->getPageRenderer()->addCssFile($baseUrl . $cssFile, 'stylesheet', 'all', '', $compress, false);
+        }
+    }
 
-	/**
-	 * Load the necessary javascript
-	 *
-	 * This will only be done when the referenced record is available
-	 *
-	 * @return void
-	 */
-	protected function loadJavascript()
-	{
-		$compress = false;
-		$javascriptFiles = array(
-			'jquery.cookie.js',
-			'jquery.cs_seo.evaluation.js'
-		);
-		// Load jquery
-		$this->getPageRenderer()->loadJquery();
+    /**
+     * Load the necessary javascript
+     *
+     * This will only be done when the referenced record is available
+     *
+     * @return void
+     */
+    protected function loadJavascript()
+    {
+        $compress = false;
+        $javascriptFiles = [
+            'jquery.cookie.js',
+            'jquery.cs_seo.evaluation.js'
+        ];
+        // Load jquery
+        $this->getPageRenderer()->loadJquery();
 
-		// Load the wizards javascript
-		$baseUrl = $this->resourcesPath . 'Public/JavaScript/';
+        // Load the wizards javascript
+        $baseUrl = $this->resourcesPath . 'Public/JavaScript/';
 
-		foreach ($javascriptFiles as $javascriptFile) {
-			$this->getPageRenderer()->addJsFile($baseUrl . $javascriptFile, 'text/javascript', $compress, false, '', true, '|', true);
-		}
-	}
+        foreach ($javascriptFiles as $javascriptFile) {
+            $this->getPageRenderer()->addJsFile(
+                $baseUrl . $javascriptFile,
+                'text/javascript',
+                $compress,
+                false,
+                '',
+                true,
+                '|',
+                true
+            );
+        }
+    }
 
 
-	/**
-	 * Add sys_notes as additional content to the footer of the page module
-	 *
-	 * @param array $params
-	 * @param PageLayoutController $parentObject
-	 * @return string
-	 */
-	public function render(array $params = array(), PageLayoutController $parentObject)
-	{
-		if($parentObject->MOD_SETTINGS['function'] == 1 && !$parentObject->modTSconfig['properties']['tx_csseo.']['disable']) {
-			$pageInfo = $parentObject->pageinfo;
-			if($this->pageCanBeIndexed($pageInfo)) {
-				// template
-				$this->loadCss();
-				$this->loadJavascript();
-				
-				//load partial paths info from typoscript
-				$this->view = GeneralUtility::makeInstance(StandaloneView::class);
-				$this->view->setFormat('html');
-				$this->view->getRequest()->setControllerExtensionName('cs_seo');
+    /**
+     * Add sys_notes as additional content to the footer of the page module
+     *
+     * @param array $params
+     * @param PageLayoutController $parentObject
+     *
+     * @return string
+     */
+    public function render(array $params, PageLayoutController $parentObject)
+    {
+        if ($parentObject->MOD_SETTINGS['function'] == 1
+            && !$parentObject->modTSconfig['properties']['tx_csseo.']['disable']
+        ) {
+            $pageInfo = $parentObject->pageinfo;
+            if ($this->pageCanBeIndexed($pageInfo)) {
+                // template
+                $this->loadCss();
+                $this->loadJavascript();
 
-				$absoluteResourcesPath = ExtensionManagementUtility::extPath('cs_seo') . 'Resources/';
-				$layoutPaths = [$absoluteResourcesPath . 'Private/Layouts/'];
-				$partialPaths = [$absoluteResourcesPath . 'Private/Partials/'];
+                //load partial paths info from typoscript
+                $this->view = GeneralUtility::makeInstance(StandaloneView::class);
+                $this->view->setFormat('html');
+                $this->view->getRequest()->setControllerExtensionName('cs_seo');
 
-				// load partial paths info from TypoScript
-				/** @var ObjectManager $objectManager */
-				$objectManager = GeneralUtility::makeInstance(ObjectManager::class);
-				/** @var ConfigurationManagerInterface $configurationManager */
-				$configurationManager = $objectManager->get(ConfigurationManagerInterface::class);
-				$tsSetup = $configurationManager->getConfiguration(ConfigurationManagerInterface::CONFIGURATION_TYPE_FRAMEWORK, 'csseo');
-				$layoutPaths = $tsSetup["view"]["layoutRootPaths"]?: $layoutPaths;
-				$partialPaths = $tsSetup["view"]["partialRootPaths"]?: $partialPaths;
+                $absoluteResourcesPath = ExtensionManagementUtility::extPath('cs_seo') . 'Resources/';
+                $layoutPaths = [$absoluteResourcesPath . 'Private/Layouts/'];
+                $partialPaths = [$absoluteResourcesPath . 'Private/Partials/'];
 
-				$this->view->setLayoutRootPaths($layoutPaths);
-				$this->view->setPartialRootPaths($partialPaths);
+                // load partial paths info from TypoScript
+                /** @var ObjectManager $objectManager */
+                $objectManager = GeneralUtility::makeInstance(ObjectManager::class);
+                /** @var ConfigurationManagerInterface $configurationManager */
+                $configurationManager = $objectManager->get(ConfigurationManagerInterface::class);
+                $tsSetup =
+                    $configurationManager->getConfiguration(
+                        ConfigurationManagerInterface::CONFIGURATION_TYPE_FRAMEWORK,
+                        'csseo'
+                    );
+                $layoutPaths = $tsSetup["view"]["layoutRootPaths"] ?: $layoutPaths;
+                $partialPaths = $tsSetup["view"]["partialRootPaths"] ?: $partialPaths;
 
-				$this->view->setTemplatePathAndFilename(ExtensionManagementUtility::extPath('cs_seo') . 'Resources/Private/Templates/PageHook.html');
+                $this->view->setLayoutRootPaths($layoutPaths);
+                $this->view->setPartialRootPaths($partialPaths);
 
-				$results = $this->getResults($pageInfo, $parentObject->current_sys_language);
-				$score = $results['Percentage'];
-				unset($results['Percentage']);
+                $this->view->setTemplatePathAndFilename(
+                    ExtensionManagementUtility::extPath('cs_seo') . 'Resources/Private/Templates/PageHook.html'
+                );
 
-				$this->view->assignMultiple([
-					'score' => $score,
-					'results'=> $results,
-					'page' => $parentObject->pageinfo
-				]);
+                $results = $this->getResults($pageInfo, $parentObject->current_sys_language);
+                $score = $results['Percentage'];
+                unset($results['Percentage']);
 
-				return $this->view->render();
-			}
-		}
-	}
+                $this->view->assignMultiple(
+                    [
+                        'score' => $score,
+                        'results' => $results,
+                        'page' => $parentObject->pageinfo
+                    ]
+                );
 
-	/**
-	 * @param array $page
-	 * @return bool
-	 */
-	public function pageCanBeIndexed($page) {
-		$allowedDoktypes = ConfigurationUtility::getEvaluationDoktypes();
-		if(in_array($page['doktype'], $allowedDoktypes) && $page['hidden'] == 0) {
-			return true;
-		}
-		return false;
-	}
+                return $this->view->render();
+            }
+        }
+    }
 
-	/**
-	 * @return PageRenderer
-	 */
-	protected function getPageRenderer()
-	{
-		if (!isset($this->pageRenderer)) {
-			$this->pageRenderer = GeneralUtility::makeInstance(PageRenderer::class);
-		}
-		return $this->pageRenderer;
-	}
+    /**
+     * @param array $page
+     *
+     * @return bool
+     */
+    public function pageCanBeIndexed($page)
+    {
+        $allowedDoktypes = ConfigurationUtility::getEvaluationDoktypes();
+        if (in_array($page['doktype'], $allowedDoktypes) && $page['hidden'] == 0) {
+            return true;
+        }
+        return false;
+    }
 
-	/**
-	 * @param $pageInfo
-	 * @param $lang
-	 * @return array
-	 */
-	protected function getResults($pageInfo, $lang)
-	{
-		$results = [];
-		
-		if($lang) {
-			$tableName = 'pages_language_overlay';
-			$localizedPageInfo = BackendUtility::getRecordLocalization('pages', $pageInfo['uid'], $lang);
-			if($localizedPageInfo[0]) {
-				$uidForeign = $localizedPageInfo[0]['uid'];
-			} else {
-				return [];
-			}
-		} else {
-			$tableName = 'pages';
-			$uidForeign = $pageInfo['uid'];
-		}
+    /**
+     * @return PageRenderer
+     */
+    protected function getPageRenderer()
+    {
+        if (!isset($this->pageRenderer)) {
+            $this->pageRenderer = GeneralUtility::makeInstance(PageRenderer::class);
+        }
+        return $this->pageRenderer;
+    }
 
-		$where = 'uid_foreign = ' . $uidForeign;
-		$where .= ' AND tablenames = "' . $tableName . '"';
+    /**
+     * @param $pageInfo
+     * @param $lang
+     *
+     * @return array
+     */
+    protected function getResults($pageInfo, $lang)
+    {
+        $results = [];
 
-		$res = $this->getDatabaseConnection()->exec_SELECTquery(
-			'results',
-			'tx_csseo_domain_model_evaluation',
-			$where
-		);
-		while ($row = $this->getDatabaseConnection()->sql_fetch_assoc($res)) {
-			$results = unserialize($row['results']);
-		}
-		return $results;
-	}
+        if ($lang) {
+            $tableName = 'pages_language_overlay';
+            $localizedPageInfo = BackendUtility::getRecordLocalization('pages', $pageInfo['uid'], $lang);
+            if ($localizedPageInfo[0]) {
+                $uidForeign = $localizedPageInfo[0]['uid'];
+            } else {
+                return [];
+            }
+        } else {
+            $tableName = 'pages';
+            $uidForeign = $pageInfo['uid'];
+        }
 
-	/**
-	 * Returns the database connection
-	 *
-	 * @return \TYPO3\CMS\Core\Database\DatabaseConnection
-	 */
-	protected function getDatabaseConnection()
-	{
-		return $GLOBALS['TYPO3_DB'];
-	}
+        $where = 'uid_foreign = ' . $uidForeign;
+        $where .= ' AND tablenames = "' . $tableName . '"';
+
+        $res = $this->getDatabaseConnection()->exec_SELECTquery(
+            'results',
+            'tx_csseo_domain_model_evaluation',
+            $where
+        );
+        while ($row = $this->getDatabaseConnection()->sql_fetch_assoc($res)) {
+            $results = unserialize($row['results']);
+        }
+        return $results;
+    }
+
+    /**
+     * Returns the database connection
+     *
+     * @return \TYPO3\CMS\Core\Database\DatabaseConnection
+     */
+    protected function getDatabaseConnection()
+    {
+        return $GLOBALS['TYPO3_DB'];
+    }
 }

--- a/Classes/Hook/RealUrlHook.php
+++ b/Classes/Hook/RealUrlHook.php
@@ -31,63 +31,71 @@ namespace Clickstorm\CsSeo\Hook;
  * Hooks for RealUrl
  *
  * Class RealUrlHook
+ *
  * @package Clickstorm\CsSeo\Hook
  */
-class RealUrlHook {
+class RealUrlHook
+{
 
-	/**
-	 * RealURL configuration array for robots.txt and sitemap.xml
-	 *
-	 * @var array
-	 */
-	protected $defaultConfiguration = [
-		'robots.txt' => [
-			'keyValues' => [
-				'type' => 656,
-			]
-		],
-		'sitemap.xml' => [
-			'keyValues' => [
-				'type' => 655,
-			]
-		]
-	];
+    /**
+     * RealURL configuration array for robots.txt and sitemap.xml
+     *
+     * @var array
+     */
+    protected $defaultConfiguration = [
+        'robots.txt' => [
+            'keyValues' => [
+                'type' => 656,
+            ]
+        ],
+        'sitemap.xml' => [
+            'keyValues' => [
+                'type' => 655,
+            ]
+        ]
+    ];
 
-	/**
-	 * Generates additional RealURL configuration for realurl autoconf and merges it with provided configuration
-	 * For detailed configuration documentation look into the manual ({@link https://wiki.typo3.org/Realurl/manual})
-	 *
-	 * @param array $parameters
-	 * @param \DmitryDulepov\Realurl\Configuration\AutomaticConfigurator $parentObject
-	 * @return array
-	 */
-	public function extensionConfiguration($parameters, &$parentObject) {
-		return $this->mergeConfiguration($parameters['config']);
-	}
+    /**
+     * Generates additional RealURL configuration for realurl autoconf and merges it with provided configuration
+     * For detailed configuration documentation look into the manual ({@link https://wiki.typo3.org/Realurl/manual})
+     *
+     * @param array $parameters
+     * @param \DmitryDulepov\Realurl\Configuration\AutomaticConfigurator $parentObject
+     *
+     * @return array
+     */
+    public function extensionConfiguration($parameters, &$parentObject)
+    {
+        return $this->mergeConfiguration($parameters['config']);
+    }
 
-	/**
-	 * Generates additional RealURL configuration for non realurl autoconf and merges it with provided configuration
-	 * For detailed configuration documentation look into the manual ({@link https://wiki.typo3.org/Realurl/manual})
-	 *
-	 * @param array $parameters
-	 * @param \DmitryDulepov\Realurl\Configuration\ConfigurationReader $parentObject
-	 * @return void
-	 */
-	public function postProcessConfiguration($parameters, &$parentObject) {
-		$parameters['configuration'] = $this->mergeConfiguration($parameters['configuration']);
-	}
+    /**
+     * Generates additional RealURL configuration for non realurl autoconf and merges it with provided configuration
+     * For detailed configuration documentation look into the manual ({@link https://wiki.typo3.org/Realurl/manual})
+     *
+     * @param array $parameters
+     * @param \DmitryDulepov\Realurl\Configuration\ConfigurationReader $parentObject
+     *
+     * @return void
+     */
+    public function postProcessConfiguration($parameters, &$parentObject)
+    {
+        $parameters['configuration'] = $this->mergeConfiguration($parameters['configuration']);
+    }
 
-	/**
-	 * @param array $conf
-	 * @return array
-	 */
-	protected function mergeConfiguration($conf) {
-		foreach ($this->defaultConfiguration as $confName => $confValue) {
-			if(!isset($conf['fileName']['index'][$confName])) {
-				$conf['fileName']['index'][$confName] =
-					$this->defaultConfiguration[$confName];
-			}
-		}
-		return $conf;
-	}
+    /**
+     * @param array $conf
+     *
+     * @return array
+     */
+    protected function mergeConfiguration($conf)
+    {
+        foreach ($this->defaultConfiguration as $confName => $confValue) {
+            if (!isset($conf['fileName']['index'][$confName])) {
+                $conf['fileName']['index'][$confName] =
+                    $this->defaultConfiguration[$confName];
+            }
+        }
+        return $conf;
+    }
 }

--- a/Classes/Service/EvaluationService.php
+++ b/Classes/Service/EvaluationService.php
@@ -26,8 +26,6 @@ namespace Clickstorm\CsSeo\Service;
  *  This copyright notice MUST APPEAR in all copies of the script!
  ***************************************************************/
 
-namespace Clickstorm\CsSeo\Service;
-
 use Clickstorm\CsSeo\Evaluation\AbstractEvaluator;
 use Clickstorm\CsSeo\Utility\ConfigurationUtility;
 use \TYPO3\CMS\Core\Utility\GeneralUtility;
@@ -36,118 +34,129 @@ use \TYPO3\CMS\Core\Utility\GeneralUtility;
  * service to evaluate a html page
  *
  * Class EvaluationService
+ *
  * @package Clickstorm\CsSeo\Service
  */
-class EvaluationService {
+class EvaluationService
+{
 
-	/**
-	 * @var array
-	 */
-	protected $evaluators;
+    /**
+     * @var array
+     */
+    protected $evaluators;
 
-	/**
-	 * @return array
-	 */
-	public function getEvaluators() {
-		return $this->evaluators;
-	}
+    /**
+     * @return array
+     */
+    public function getEvaluators()
+    {
+        return $this->evaluators;
+    }
 
-	/**
-	 * @param array $evaluators
-	 */
-	public function setEvaluators($evaluators) {
-		$this->evaluators = $evaluators;
-	}
+    /**
+     * @param array $evaluators
+     */
+    public function setEvaluators($evaluators)
+    {
+        $this->evaluators = $evaluators;
+    }
 
-	/**
-	 * @TODO find a better solution for defaults
-	 */
-	public function initEvaluators() {
-		$evaluators = [];
-		$extConf = ConfigurationUtility::getEmConfiguration();
+    /**
+     * @TODO find a better solution for defaults
+     */
+    public function initEvaluators()
+    {
+        $evaluators = [];
+        $extConf = ConfigurationUtility::getEmConfiguration();
 
-		// default
-		$availableEvaluators = [
-			'H1' => \Clickstorm\CsSeo\Evaluation\H1Evaluator::class,
-			'H2' => \Clickstorm\CsSeo\Evaluation\H2Evaluator::class,
-			'Title' => \Clickstorm\CsSeo\Evaluation\TitleEvaluator::class,
-			'Description' => \Clickstorm\CsSeo\Evaluation\DescriptionEvaluator::class,
-			'Keyword' => \Clickstorm\CsSeo\Evaluation\KeywordEvaluator::class,
-			'Images' => \Clickstorm\CsSeo\Evaluation\ImagesEvaluator::class
-		];
+        // default
+        $availableEvaluators = [
+            'H1' => \Clickstorm\CsSeo\Evaluation\H1Evaluator::class,
+            'H2' => \Clickstorm\CsSeo\Evaluation\H2Evaluator::class,
+            'Title' => \Clickstorm\CsSeo\Evaluation\TitleEvaluator::class,
+            'Description' => \Clickstorm\CsSeo\Evaluation\DescriptionEvaluator::class,
+            'Keyword' => \Clickstorm\CsSeo\Evaluation\KeywordEvaluator::class,
+            'Images' => \Clickstorm\CsSeo\Evaluation\ImagesEvaluator::class
+        ];
 
-		// additional evaluators
-		if (is_array($GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['cs_seo']['evaluators'])) {
-			$availableEvaluators = array_merge($availableEvaluators, $GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['cs_seo']['evaluators']);
-		}
+        // additional evaluators
+        if (is_array($GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['cs_seo']['evaluators'])) {
+            $availableEvaluators =
+                array_merge($availableEvaluators, $GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['cs_seo']['evaluators']);
+        }
 
-		// select the final evaluators
-		if(empty($extConf['evaluators'])) {
-			$evaluators = $availableEvaluators;
-		} else {
-			foreach (GeneralUtility::trimExplode(',', $extConf['evaluators']) as $evaluator) {
-				if(isset($availableEvaluators[$evaluator])) {
-					$evaluators[$evaluator] = $availableEvaluators[$evaluator];
-				}
-			}
-		}
+        // select the final evaluators
+        if (empty($extConf['evaluators'])) {
+            $evaluators = $availableEvaluators;
+        } else {
+            foreach (GeneralUtility::trimExplode(',', $extConf['evaluators']) as $evaluator) {
+                if (isset($availableEvaluators[$evaluator])) {
+                    $evaluators[$evaluator] = $availableEvaluators[$evaluator];
+                }
+            }
+        }
 
 
-		$this->evaluators = $evaluators;
-	}
+        $this->evaluators = $evaluators;
+    }
 
-    public function evaluate($html, $keyword) {
-	    $results = [];
+    public function evaluate($html, $keyword)
+    {
+        $results = [];
 
-	    $this->initEvaluators();
+        $this->initEvaluators();
 
-	    $domDocument = new \DOMDocument;
-	    @$domDocument->loadHTML(mb_convert_encoding($html, 'HTML-ENTITIES', 'UTF-8'));
+        $domDocument = new \DOMDocument;
+        @$domDocument->loadHTML(mb_convert_encoding($html, 'HTML-ENTITIES', 'UTF-8'));
 
-	    foreach ($this->evaluators as $evaluatorName => $evaluatorClass) {
-	    	$evaluatorInstance = GeneralUtility::makeInstance($evaluatorClass, $domDocument, $keyword);
-			$results[$evaluatorName] = $evaluatorInstance->evaluate();
-	    }
+        foreach ($this->evaluators as $evaluatorName => $evaluatorClass) {
+            $evaluatorInstance = GeneralUtility::makeInstance($evaluatorClass, $domDocument, $keyword);
+            $results[$evaluatorName] = $evaluatorInstance->evaluate();
+        }
 
-	    uasort($results, function($a, $b) {
-		    return $a['state'] - $b['state'];
-	    });
+        uasort(
+            $results,
+            function ($a, $b) {
+                return $a['state'] - $b['state'];
+            }
+        );
 
-	    $results['Percentage'] = $this->getFinalPercentage($results);
+        $results['Percentage'] = $this->getFinalPercentage($results);
 
-	    return $results;
+        return $results;
     }
 
 
+    /**
+     * @param $results
+     *
+     * @return array
+     */
+    protected function getFinalPercentage($results)
+    {
+        $score = 0;
+        $count = 0;
 
-	/**
-	 * @param $results
-	 * @return array
-	 */
-    protected function getFinalPercentage($results) {
-    	$score = 0;
-	    $count = 0;
+        $state = AbstractEvaluator::STATE_RED;
+        foreach ($results as $result) {
+            $score += $result['state'];
+        }
 
-	    $state = AbstractEvaluator::STATE_RED;
-	    foreach ($results as $result) {
-			$score += $result['state'];
-		}
+        $total = (count($results) * 2);
 
-		$total = (count($results) * 2);
+        if ($total > 0) {
+            $count = round($score / $total * 100);
+        }
 
-	    if($total > 0) {
-		    $count = round($score / $total * 100) ;
-	    }
+        if ($count == 100) {
+            $state = AbstractEvaluator::STATE_GREEN;
+        } elseif ($count > 40) {
+            $state = AbstractEvaluator::STATE_YELLOW;
+        }
 
-	    if($count == 100) {
-	    	$state = AbstractEvaluator::STATE_GREEN;
-	    } elseif($count > 40) {
-		    $state = AbstractEvaluator::STATE_YELLOW;
-	    }
-
-	    return [
-		    'state' => $state,
-		    'count' => $count
-	    ];
+        return [
+            'state' => $state,
+            'count' => $count
+        ];
     }
 }

--- a/Classes/Service/FrontendPageService.php
+++ b/Classes/Service/FrontendPageService.php
@@ -36,56 +36,61 @@ use \TYPO3\CMS\Core\Utility\GeneralUtility;
  * crawl the page
  *
  * Class FrontendPageService
+ *
  * @package Clickstorm\CsSeo\Service
  */
-class FrontendPageService {
+class FrontendPageService
+{
 
-	/**
-	 * @var array
-	 */
-	protected $pageInfo;
+    /**
+     * @var array
+     */
+    protected $pageInfo;
 
-	/**
-	 * @var int
-	 */
-	protected $lang;
+    /**
+     * @var int
+     */
+    protected $lang;
 
-	/**
-	 * TSFEUtility constructor.
-	 * @param array $pageInfo
-	 */
-	public function __construct($pageInfo) {
-		$this->pageInfo = $pageInfo;
-	}
+    /**
+     * TSFEUtility constructor.
+     *
+     * @param array $pageInfo
+     */
+    public function __construct($pageInfo)
+    {
+        $this->pageInfo = $pageInfo;
+    }
 
-	/**
-	 * @return string
-	 */
-	public function getHTML() {
-		$allowedDoktypes = ConfigurationUtility::getEvaluationDoktypes();
-		if(!in_array($this->pageInfo['doktype'], $allowedDoktypes) || $this->pageInfo['tx_csseo_no_index']) {
-			return '';
-		}
+    /**
+     * @return string
+     */
+    public function getHTML()
+    {
+        $allowedDoktypes = ConfigurationUtility::getEvaluationDoktypes();
+        if (!in_array($this->pageInfo['doktype'], $allowedDoktypes) || $this->pageInfo['tx_csseo_no_index']) {
+            return '';
+        }
 
         // add id and language
-		if($this->pageInfo['sys_language_uid'] > 0) {
-			$pid = $this->pageInfo['pid'];
-			$params = 'id=' . $pid . '&L=' . $this->pageInfo['sys_language_uid'];
-		} else {
-			$pid = $this->pageInfo['uid'];
-			$params = 'id=' . $pid;
-		}
+        if ($this->pageInfo['sys_language_uid'] > 0) {
+            $pid = $this->pageInfo['pid'];
+            $params = 'id=' . $pid . '&L=' . $this->pageInfo['sys_language_uid'];
+        } else {
+            $pid = $this->pageInfo['uid'];
+            $params = 'id=' . $pid;
+        }
 
         // disable cache
         $params .= '&no_cache=1';
 
-		$domain = BackendUtility::getViewDomain($pid);
-		$url = $domain . '/index.php?' . $params;
+        $domain = BackendUtility::getViewDomain($pid);
+        $url = $domain . '/index.php?' . $params;
 
-		$report = [];
-		$content = GeneralUtility::getUrl($url, 0, false, $report);
+        $report = [];
+        $content = GeneralUtility::getUrl($url, 0, false, $report);
 
-        if($report['message'] && $report['message'] != 'OK') {
+        if ($report['message'] && $report['message'] != 'OK') {
             /** @var \TYPO3\CMS\Core\Messaging\FlashMessage $flashMessage */
             $flashMessage = GeneralUtility::makeInstance(
                 FlashMessage::class,
@@ -100,6 +105,6 @@ class FrontendPageService {
             $flashMessageQueue->enqueue($flashMessage);
         }
 
-		return in_array($report['error'], [0, 200]) ? $content : '';
-	}
+        return in_array($report['error'], [0, 200]) ? $content : '';
+    }
 }

--- a/Classes/UserFunc/HeaderData.php
+++ b/Classes/UserFunc/HeaderData.php
@@ -36,450 +36,493 @@ use TYPO3\CMS\Frontend\ContentObject\ContentObjectRenderer;
  *
  * @package Clickstorm\CsSeo\UserFunc
  */
-class HeaderData {
-
-	/**
-	 * @var \TYPO3\CMS\Frontend\ContentObject\ContentObjectRenderer
-	 */
-	public $cObj;
-
-	function __construct() {
-		$this->cObj = GeneralUtility::makeInstance(ContentObjectRenderer::class);
-	}
-
-	/**
-	 * check if GP parameter is set
-	 * @return boolean
-	 */
-	public static function checkSeoGP() {
-
-		// get table settings
-		$tables = ConfigurationUtility::getPageTSconfig();
-
-		if ($tables) {
-			$cObj = GeneralUtility::makeInstance(ContentObjectRenderer::class);
-
-			// get active table name und uid
-			$gpSEO = self::getCurrentTable($tables, $cObj, true);
-
-			if ($gpSEO) {
-				return true;
-			}
-		}
-
-		return false;
-	}
-
-	/**
-	 * Check if extension detail view or page properties should be used
-	 *
-	 * @param $tables
-	 * @param \TYPO3\CMS\Frontend\ContentObject\ContentObjectRenderer $cObj
-	 * @param bool $checkOnly
-	 * @return array|bool
-	 */
-	public static function getCurrentTable($tables, $cObj, $checkOnly = false) {
-		foreach ($tables as $key => $table) {
-			if (isset($tables[$key . '.']['enable'])) {
-				$settings = $tables[$key . '.'];
-				$uid = intval($cObj->getData($settings['enable']));
-
-				if ($uid) {
-					if ($checkOnly) {
-						return true;
-					}
-					$data = array(
-						'table' => $table,
-						'uid' => $uid,
-					);
-
-					if (isset($settings['fallback.']) && count($settings['fallback.']) > 0) {
-						$data['fallback'] = $settings['fallback.'];
-					}
-
-					return $data;
-				}
-			}
-		}
-
-		// page
-		$pagesTable = $GLOBALS['TSFE']->sys_language_uid > 0 ? 'pages_language_overlay' : 'pages';
-		if (in_array($pagesTable, $tables)) {
-			$pageUid = $GLOBALS['TSFE']->page['_PAGES_OVERLAY_UID'] ?: $GLOBALS['TSFE']->id;
-
-			return array($pagesTable, $pageUid);
-		}
-
-		return false;
-	}
-
-	/**
-	 * @return bool|string meta tags, if available
-	 */
-	public function getMetaTags($content, $conf) {
-		// get table settings
-		$tables = ConfigurationUtility::getPageTSconfig();
-
-		if ($tables) {
-			// get active table name und settings
-			$tableSettings = $this->getCurrentTable($tables, $this->cObj);
-
-			if ($tableSettings) {
-				// get record
-				$record = $this->getRecord($tableSettings);
-
-				if ($record['_LOCALIZED_UID']) {
-					$tableSettings['uid'] = $record['_LOCALIZED_UID'];
-				}
-				// db meta
-				$meta = $this->getMetaProperties($tableSettings);
-
-				// db fallback
-				if (isset($tableSettings['fallback'])) {
-					foreach ($tableSettings['fallback'] as $seoField => $fallbackField) {
-						if (empty($meta[$seoField]) && !empty($record[$fallbackField])) {
-							$meta[$seoField] = $record[$fallbackField];
-						}
-					}
-				}
-
-				// render content
-				$headerData = $this->renderContent($meta);
-
-				return $headerData;
-			}
-		}
-
-		return false;
-	}
-
-	/**
-	 * DB query to get the fallback properties
-	 *
-	 * @param $tableSettings
-	 * @return bool
-	 */
-	protected function getRecord($tableSettings) {
-		$where = 'uid = ' . $tableSettings['uid'];
-		$where .= $GLOBALS['TSFE']->sys_page->enableFields($tableSettings['table']);
-		$res = $GLOBALS['TYPO3_DB']->exec_SELECTgetRows(
-			'*',
-			$tableSettings['table'],
-			$where,
-			'',
-			'',
-			1
-		);
-		$row = $res[0];
-
-		if (is_array(
-				$row
-			) && $row['sys_language_uid'] != $GLOBALS['TSFE']->sys_language_content && $GLOBALS['TSFE']->sys_language_contentOL
-		) {
-			$rowOL = $GLOBALS['TSFE']->sys_page->getRecordOverlay(
-				$tableSettings['table'],
-				$row,
-				$GLOBALS['TSFE']->sys_language_content,
-				$GLOBALS['TSFE']->sys_language_contentOL
-			);
-
-			if (!empty($rowOL)) {
-				$row = $rowOL;
-			}
-		}
-
-		return $row;
-	}
-
-	/**
-	 * DB query to get the current meta properties
-	 *
-	 * @param $tableSettings
-	 * @return bool
-	 */
-	protected function getMetaProperties($tableSettings) {
-		$res = $GLOBALS['TYPO3_DB']->exec_SELECTgetRows(
-			'*',
-			'tx_csseo_domain_model_meta',
-			'tablenames = "' . $tableSettings['table'] . '" AND uid_foreign = ' . $tableSettings['uid'] . ' AND deleted=0',
-			'',
-			'',
-			1
-		);
-
-		return isset($res[0]) ? $res[0] : [];
-	}
-
-	/**
-	 * render the meta tags
-	 *
-	 * @param $meta
-	 * @return string
-	 */
-	protected function renderContent($meta) {
-		/** @var \Clickstorm\CsSeo\Utility\TSFEUtility $tsfeUtility */
-		$tsfeUtility = GeneralUtility::makeInstance(\Clickstorm\CsSeo\Utility\TSFEUtility::class, $GLOBALS['TSFE']->id);
-		$pluginSettings = $GLOBALS['TSFE']->tmpl->setup['plugin.']['tx_csseo.'];
-
-		$content = '';
-		$title = $meta['title'];
-
-		// title
-		if ($title) {
-			$title = $tsfeUtility->getFinalTitle($meta['title'], $meta['title_only']);
-		} else {
-			// fallback to page title
-			$pageTitleFunc = GeneralUtility::makeInstance(PageTitle::class);
-			$title = $pageTitleFunc->render('', array());
-		}
-
-		$content .= '<title>' . $this->escapeContent($title) . '</title>';
-
-		// description
-		$content .= $this->printMetaTag('description', $this->escapeContent($meta['description']));
-
-		// hreflang & canonical
-		$typoLinkConf = $GLOBALS['TSFE']->tmpl->setup['lib.']['currentUrl.']['typolink.'];
-		unset($typoLinkConf['parameter.']);
-		$typoLinkConf['parameter'] = $GLOBALS['TSFE']->id;
-
-		// get active table and uid
-		$tables = self::getPageTS();
-		$cObj = GeneralUtility::makeInstance(ContentObjectRenderer::class);
-		$currentItem = self::getCurrentTable($tables, $cObj);
-
-		$allLanguagesFromItem = $this->getAllLanguagesFromItem($currentItem['table'], $currentItem['uid']);
-
-		$currentLanguageUid = $GLOBALS['TSFE']->sys_language_uid;
-
-		// canonical
-		$canonicalTypoLinkConf = [];
-		if($meta['canonical']) {
-			$canonicalTypoLinkConf['parameter'] = $meta['canonical'];
-			$canonicalTypoLinkConf['forceAbsoluteUrl'] = 1;
-		} else {
-			$canonicalTypoLinkConf = $typoLinkConf;
-
-			// if a fallback is shown, set canonical to the language of the ordered item
-			if (!in_array($currentLanguageUid, $allLanguagesFromItem)) {
-				unset($canonicalTypoLinkConf['additionalParams.']);
-				$canonicalTypoLinkConf['additionalParams'] = '&L=' . $this->getLanguageFromItem($currentItem['table'], $currentItem['uid']);
-			}
-		}
-		$canonical = $this->cObj->typoLink_URL($canonicalTypoLinkConf);
-
-		// index
-		if ($meta['no_index']) {
-			$content .= $this->printMetaTag('robots', 'noindex,nofollow');
-		} else {
-			$content .= '<link rel="canonical" href="' . $canonical . '" />';
-		}
-
-		// hreflang
-		// if the item for the current language uid exists and
-		// the item is not set to no index and
-		// the item points not to another page as canonical and
-		// the TS setting hreflang.enabled is set to 1
-		if (in_array(
-				$currentLanguageUid,
-				$allLanguagesFromItem
-			) && !$meta['no_index'] && !$meta['canonical'] && $GLOBALS['TSFE']->tmpl->setup['plugin.']['tx_csseo.']['hreflang.']['enable']
-		) {
-			$langIds = explode(",", $GLOBALS['TSFE']->tmpl->setup['plugin.']['tx_csseo.']['hreflang.']['ids']);
-			$langKeys = explode(",", $GLOBALS['TSFE']->tmpl->setup['plugin.']['tx_csseo.']['hreflang.']['keys']);
-
-			$hreflangTypoLinkConf = $typoLinkConf;
-
-			foreach ($langIds as $key => $langId) {
-				// set hreflang only for languages of the TS setup and if the language is also localized for the item
-				// if the language doesn't exist for the item and a fallback language is shown, the hreflang is not set and the canonical points to the fallback url
-				if (in_array($langId, $allLanguagesFromItem)) {
-					unset($hreflangTypoLinkConf['additionalParams.']);
-					$hreflangTypoLinkConf['additionalParams'] = '&L=' . $langId;
-					$hreflangUrl = $this->cObj->typoLink_URL($hreflangTypoLinkConf);
-					$content .= '<link rel="alternate" hreflang="' . $langKeys[$key] . '" href="' . $hreflangUrl . '" />';
-				}
-			}
-		}
-
-		// og:title
-		$ogTitle = $meta['og_title'] ?: $title;
-		$content .= $this->printMetaTag('og:title', $this->escapeContent($ogTitle), 1);
-
-		// og:description
-		$ogDescription = $meta['og_description'] ?: $meta['description'];
-		$content .= $this->printMetaTag('og:description', $this->escapeContent($ogDescription), 1);
-
-		// og:image
-		$ogImageURL = $pluginSettings['social.']['defaultImage'];
-
-		if ($meta['og_image']) {
-			$ogImageURL = $this->getImagePath('og_image', $meta['uid']);
-		}
-
-		if ($ogImageURL) {
-			$finalOgImageURL = $this->getScaledImagePath(
-				$ogImageURL,
-				$pluginSettings['social.']['openGraph.']['image.']
-			);
-			$content .= $this->printMetaTag('og:image', $finalOgImageURL, 1);
-		}
-
-		// og:type
-		$content .= $this->printMetaTag('og:type', 'website', 1);
-
-		// og:url
-		$content .= $this->printMetaTag('og:url', $canonical, 1);
-
-		// og:locale
-		$content .= $this->printMetaTag('og:locale', $GLOBALS['TSFE']->config['config']['locale_all'], 1);
-
-		// og:site_name
-		$content .= $this->printMetaTag('og:site_name', $this->escapeContent($GLOBALS['TSFE']->tmpl->sitetitle), 1);
-
-		// twitter title
-		if ($meta['tw_title']) {
-			$content .= $this->printMetaTag('twitter:title', $this->escapeContent($meta['tw_title']));
-		}
-
-		// twitter description
-		if ($meta['tw_description']) {
-			$content .= $this->printMetaTag('twitter:description', $this->escapeContent($meta['tw_description']));
-		}
-
-		// twitter image and type
-		if ($meta['tw_image'] || $meta['og_image']) {
-			if ($meta['tw_image']) {
-				$twImageURL = $this->getImagePath('tw_image', $meta['uid']);
-			} else {
-				$twImageURL = $ogImageURL;
-			}
-			$content .= $this->printMetaTag('twitter:card', 'summary_large_image');
-		} else {
-			$twImageURL = $pluginSettings['social.']['twitter.']['defaultImage'] ?: $pluginSettings['social.']['defaultImage'];
-			$content .= $this->printMetaTag('twitter:card', 'summary');
-		}
-
-		if ($twImageURL) {
-			$finalTwImageURL = $this->getScaledImagePath($twImageURL, $pluginSettings['social.']['twitter.']['image.']);
-			$content .= $this->printMetaTag('twitter:image', $finalTwImageURL);
-		}
-
-		// creator
-		$content .= $this->printMetaTag(
-			'twitter:creator',
-			$this->escapeContent($meta['tw_creator'] ?: $pluginSettings['social.']['twitter.']['creator'])
-		);
-
-		return $content;
-	}
-
-	/**
-	 * @param string $content
-	 * @return string
-	 */
-	protected function escapeContent($content) {
-		return htmlentities(preg_replace('/\s\s+/', ' ', preg_replace('#<[^>]+>#', ' ', $content)));
-	}
-
-	/**
-	 * @param string $name
-	 * @param string $value
-	 * @param bool $property
-	 * @return string
-	 */
-	protected function printMetaTag($name, $value, $property = false) {
-		if (empty($value)) {
-			return '';
-		}
-
-		$propertyString = $property ? 'property' : 'name';
-
-		return '<meta ' . $propertyString . '="' . $name . '" content="' . $value . '" />';
-	}
-
-	/**
-	 * @param string $table
-	 * @param string $uid
-	 * @return array
-	 */
-	protected function getAllLanguagesFromItem($table, $uid) {
-		$languageIds = array();
-
-		$pointerField = isset($GLOBALS['TCA'][$table]['ctrl']['transOrigPointerField']) ? $GLOBALS['TCA'][$table]['ctrl']['transOrigPointerField']: 'l10n_parent';
-
-		$languageField = isset($GLOBALS['TCA'][$table]['ctrl']['languageField']) ? $GLOBALS['TCA'][$table]['ctrl']['languageField']: 'sys_language_uid';
-
-		$whereClause = '('.$pointerField.' = ' . $uid . ' OR uid = ' . $uid . ')';
-		$whereClause .= $GLOBALS['TSFE']->sys_page->enableFields($table);
-
-		$allItems = $GLOBALS['TYPO3_DB']->exec_SELECTgetRows($languageField, $table, $whereClause);
-
-		foreach ($allItems as $item) {
-			$languageIds[] = $item[$languageField];
-		}
-
-		return $languageIds;
-	}
-
-	/**
-	 * @param string $table
-	 * @param string $uid
-	 * @return array
-	 */
-	protected function getLanguageFromItem($table, $uid) {
-		$whereClause = 'uid = ' . $uid;
-		$whereClause .= $GLOBALS['TSFE']->sys_page->enableFields($table);
-		$item = $GLOBALS['TYPO3_DB']->exec_SELECTgetRows('sys_language_uid', $table, $whereClause);
-
-		return $item[0]['sys_language_uid'];
-	}
-
-	/**
-	 * Returns an image path for the given field and uid
-	 *
-	 * @param string $field
-	 * @param string $uid
-	 * @return string the image path
-	 */
-	protected function getImagePath($field, $uid) {
-		/** @var \TYPO3\CMS\Core\Resource\FileRepository $fileRepository */
-		$fileRepository = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance(
-			\TYPO3\CMS\Core\Resource\FileRepository::class
-		);
-		$fileObjects = $fileRepository->findByRelation(
-			'tx_csseo_domain_model_meta',
-			'tx_csseo_' . $field,
-			$uid
-		);
-
-		if ($fileObjects[0]) {
-			return $fileObjects[0]->getOriginalFile()->getPublicUrl();
-		}
-
-	}
-
-	/**
-	 * Return an URL to the scaled image
-	 *
-	 * @param string $originalFile uid or path of the file
-	 * @param array $imageSize width and height as keys
-	 * @return string
-	 */
-	protected function getScaledImagePath($originalFile, $imageSize) {
-		$conf = array(
-			'file' => $originalFile,
-			'file.' => array(
-				'height' => $imageSize['height'],
-				'width' => $imageSize['width']
-			)
-		);
-		$imgUri = $this->cObj->cObjGetSingle('IMG_RESOURCE', $conf);
-		$conf = array(
-			'parameter' => $imgUri,
-			'forceAbsoluteUrl' => 1
-		);
-
-		return $this->cObj->typoLink_URL($conf);
-	}
+class HeaderData
+{
+
+    /**
+     * @var \TYPO3\CMS\Frontend\ContentObject\ContentObjectRenderer
+     */
+    public $cObj;
+
+    public function __construct()
+    {
+        $this->cObj = GeneralUtility::makeInstance(ContentObjectRenderer::class);
+    }
+
+    /**
+     * check if GP parameter is set
+     *
+     * @return boolean
+     */
+    public static function checkSeoGP()
+    {
+
+        // get table settings
+        $tables = ConfigurationUtility::getPageTSconfig();
+
+        if ($tables) {
+            $cObj = GeneralUtility::makeInstance(ContentObjectRenderer::class);
+
+            // get active table name und uid
+            $gpSEO = self::getCurrentTable($tables, $cObj, true);
+
+            if ($gpSEO) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Check if extension detail view or page properties should be used
+     *
+     * @param $tables
+     * @param \TYPO3\CMS\Frontend\ContentObject\ContentObjectRenderer $cObj
+     * @param bool $checkOnly
+     *
+     * @return array|bool
+     */
+    public static function getCurrentTable($tables, $cObj, $checkOnly = false)
+    {
+        foreach ($tables as $key => $table) {
+            if (isset($tables[$key . '.']['enable'])) {
+                $settings = $tables[$key . '.'];
+                $uid = intval($cObj->getData($settings['enable']));
+
+                if ($uid) {
+                    if ($checkOnly) {
+                        return true;
+                    }
+                    $data = [
+                        'table' => $table,
+                        'uid' => $uid,
+                    ];
+
+                    if (isset($settings['fallback.']) && count($settings['fallback.']) > 0) {
+                        $data['fallback'] = $settings['fallback.'];
+                    }
+
+                    return $data;
+                }
+            }
+        }
+
+        // page
+        $pagesTable = $GLOBALS['TSFE']->sys_language_uid > 0 ? 'pages_language_overlay' : 'pages';
+        if (in_array($pagesTable, $tables)) {
+            $pageUid = $GLOBALS['TSFE']->page['_PAGES_OVERLAY_UID'] ?: $GLOBALS['TSFE']->id;
+
+            return [$pagesTable, $pageUid];
+        }
+
+        return false;
+    }
+
+    /**
+     * @return bool|string meta tags, if available
+     */
+    public function getMetaTags($content, $conf)
+    {
+        // get table settings
+        $tables = ConfigurationUtility::getPageTSconfig();
+
+        if ($tables) {
+            // get active table name und settings
+            $tableSettings = $this->getCurrentTable($tables, $this->cObj);
+
+            if ($tableSettings) {
+                // get record
+                $record = $this->getRecord($tableSettings);
+
+                if ($record['_LOCALIZED_UID']) {
+                    $tableSettings['uid'] = $record['_LOCALIZED_UID'];
+                }
+                // db meta
+                $meta = $this->getMetaProperties($tableSettings);
+
+                // db fallback
+                if (isset($tableSettings['fallback'])) {
+                    foreach ($tableSettings['fallback'] as $seoField => $fallbackField) {
+                        if (empty($meta[$seoField]) && !empty($record[$fallbackField])) {
+                            $meta[$seoField] = $record[$fallbackField];
+                        }
+                    }
+                }
+
+                // render content
+                $headerData = $this->renderContent($meta);
+
+                return $headerData;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * DB query to get the fallback properties
+     *
+     * @param $tableSettings
+     *
+     * @return bool
+     */
+    protected function getRecord($tableSettings)
+    {
+        $where = 'uid = ' . $tableSettings['uid'];
+        $where .= $GLOBALS['TSFE']->sys_page->enableFields($tableSettings['table']);
+        $res = $GLOBALS['TYPO3_DB']->exec_SELECTgetRows(
+            '*',
+            $tableSettings['table'],
+            $where,
+            '',
+            '',
+            1
+        );
+        $row = $res[0];
+
+        if (is_array(
+            $row
+        )
+            && $row['sys_language_uid'] != $GLOBALS['TSFE']->sys_language_content
+            && $GLOBALS['TSFE']->sys_language_contentOL
+        ) {
+            $rowOL = $GLOBALS['TSFE']->sys_page->getRecordOverlay(
+                $tableSettings['table'],
+                $row,
+                $GLOBALS['TSFE']->sys_language_content,
+                $GLOBALS['TSFE']->sys_language_contentOL
+            );
+
+            if (!empty($rowOL)) {
+                $row = $rowOL;
+            }
+        }
+
+        return $row;
+    }
+
+    /**
+     * DB query to get the current meta properties
+     *
+     * @param $tableSettings
+     *
+     * @return bool
+     */
+    protected function getMetaProperties($tableSettings)
+    {
+        $res = $GLOBALS['TYPO3_DB']->exec_SELECTgetRows(
+            '*',
+            'tx_csseo_domain_model_meta',
+            'tablenames = "'
+            . $tableSettings['table']
+            . '" AND uid_foreign = '
+            . $tableSettings['uid']
+            . ' AND deleted=0',
+            '',
+            '',
+            1
+        );
+
+        return isset($res[0]) ? $res[0] : [];
+    }
+
+    /**
+     * render the meta tags
+     *
+     * @param $meta
+     *
+     * @return string
+     */
+    protected function renderContent($meta)
+    {
+        /** @var \Clickstorm\CsSeo\Utility\TSFEUtility $tsfeUtility */
+        $tsfeUtility = GeneralUtility::makeInstance(\Clickstorm\CsSeo\Utility\TSFEUtility::class, $GLOBALS['TSFE']->id);
+        $pluginSettings = $GLOBALS['TSFE']->tmpl->setup['plugin.']['tx_csseo.'];
+
+        $content = '';
+        $title = $meta['title'];
+
+        // title
+        if ($title) {
+            $title = $tsfeUtility->getFinalTitle($meta['title'], $meta['title_only']);
+        } else {
+            // fallback to page title
+            $pageTitleFunc = GeneralUtility::makeInstance(PageTitle::class);
+            $title = $pageTitleFunc->render('', []);
+        }
+
+        $content .= '<title>' . $this->escapeContent($title) . '</title>';
+
+        // description
+        $content .= $this->printMetaTag('description', $this->escapeContent($meta['description']));
+
+        // hreflang & canonical
+        $typoLinkConf = $GLOBALS['TSFE']->tmpl->setup['lib.']['currentUrl.']['typolink.'];
+        unset($typoLinkConf['parameter.']);
+        $typoLinkConf['parameter'] = $GLOBALS['TSFE']->id;
+
+        // get active table and uid
+        $tables = self::getPageTS();
+        $cObj = GeneralUtility::makeInstance(ContentObjectRenderer::class);
+        $currentItem = self::getCurrentTable($tables, $cObj);
+
+        $allLanguagesFromItem = $this->getAllLanguagesFromItem($currentItem['table'], $currentItem['uid']);
+
+        $currentLanguageUid = $GLOBALS['TSFE']->sys_language_uid;
+
+        // canonical
+        $canonicalTypoLinkConf = [];
+        if ($meta['canonical']) {
+            $canonicalTypoLinkConf['parameter'] = $meta['canonical'];
+            $canonicalTypoLinkConf['forceAbsoluteUrl'] = 1;
+        } else {
+            $canonicalTypoLinkConf = $typoLinkConf;
+
+            // if a fallback is shown, set canonical to the language of the ordered item
+            if (!in_array($currentLanguageUid, $allLanguagesFromItem)) {
+                unset($canonicalTypoLinkConf['additionalParams.']);
+                $canonicalTypoLinkConf['additionalParams'] =
+                    '&L=' . $this->getLanguageFromItem($currentItem['table'], $currentItem['uid']);
+            }
+        }
+        $canonical = $this->cObj->typoLink_URL($canonicalTypoLinkConf);
+
+        // index
+        if ($meta['no_index']) {
+            $content .= $this->printMetaTag('robots', 'noindex,nofollow');
+        } else {
+            $content .= '<link rel="canonical" href="' . $canonical . '" />';
+        }
+
+        // hreflang
+        // if the item for the current language uid exists and
+        // the item is not set to no index and
+        // the item points not to another page as canonical and
+        // the TS setting hreflang.enabled is set to 1
+        if (in_array(
+            $currentLanguageUid,
+            $allLanguagesFromItem
+        )
+            && !$meta['no_index']
+            && !$meta['canonical']
+            && $GLOBALS['TSFE']->tmpl->setup['plugin.']['tx_csseo.']['hreflang.']['enable']
+        ) {
+            $langIds = explode(",", $GLOBALS['TSFE']->tmpl->setup['plugin.']['tx_csseo.']['hreflang.']['ids']);
+            $langKeys = explode(",", $GLOBALS['TSFE']->tmpl->setup['plugin.']['tx_csseo.']['hreflang.']['keys']);
+
+            $hreflangTypoLinkConf = $typoLinkConf;
+
+            foreach ($langIds as $key => $langId) {
+                // set hreflang only for languages of the TS setup and if the language is also localized for the item
+                // if the language doesn't exist for the item and a fallback language is shown, the hreflang is not set and the canonical points to the fallback url
+                if (in_array($langId, $allLanguagesFromItem)) {
+                    unset($hreflangTypoLinkConf['additionalParams.']);
+                    $hreflangTypoLinkConf['additionalParams'] = '&L=' . $langId;
+                    $hreflangUrl = $this->cObj->typoLink_URL($hreflangTypoLinkConf);
+                    $content .= '<link rel="alternate" hreflang="'
+                        . $langKeys[$key]
+                        . '" href="'
+                        . $hreflangUrl
+                        . '" />';
+                }
+            }
+        }
+
+        // og:title
+        $ogTitle = $meta['og_title'] ?: $title;
+        $content .= $this->printMetaTag('og:title', $this->escapeContent($ogTitle), 1);
+
+        // og:description
+        $ogDescription = $meta['og_description'] ?: $meta['description'];
+        $content .= $this->printMetaTag('og:description', $this->escapeContent($ogDescription), 1);
+
+        // og:image
+        $ogImageURL = $pluginSettings['social.']['defaultImage'];
+
+        if ($meta['og_image']) {
+            $ogImageURL = $this->getImagePath('og_image', $meta['uid']);
+        }
+
+        if ($ogImageURL) {
+            $finalOgImageURL = $this->getScaledImagePath(
+                $ogImageURL,
+                $pluginSettings['social.']['openGraph.']['image.']
+            );
+            $content .= $this->printMetaTag('og:image', $finalOgImageURL, 1);
+        }
+
+        // og:type
+        $content .= $this->printMetaTag('og:type', 'website', 1);
+
+        // og:url
+        $content .= $this->printMetaTag('og:url', $canonical, 1);
+
+        // og:locale
+        $content .= $this->printMetaTag('og:locale', $GLOBALS['TSFE']->config['config']['locale_all'], 1);
+
+        // og:site_name
+        $content .= $this->printMetaTag('og:site_name', $this->escapeContent($GLOBALS['TSFE']->tmpl->sitetitle), 1);
+
+        // twitter title
+        if ($meta['tw_title']) {
+            $content .= $this->printMetaTag('twitter:title', $this->escapeContent($meta['tw_title']));
+        }
+
+        // twitter description
+        if ($meta['tw_description']) {
+            $content .= $this->printMetaTag('twitter:description', $this->escapeContent($meta['tw_description']));
+        }
+
+        // twitter image and type
+        if ($meta['tw_image'] || $meta['og_image']) {
+            if ($meta['tw_image']) {
+                $twImageURL = $this->getImagePath('tw_image', $meta['uid']);
+            } else {
+                $twImageURL = $ogImageURL;
+            }
+            $content .= $this->printMetaTag('twitter:card', 'summary_large_image');
+        } else {
+            $twImageURL =
+                $pluginSettings['social.']['twitter.']['defaultImage'] ?: $pluginSettings['social.']['defaultImage'];
+            $content .= $this->printMetaTag('twitter:card', 'summary');
+        }
+
+        if ($twImageURL) {
+            $finalTwImageURL = $this->getScaledImagePath($twImageURL, $pluginSettings['social.']['twitter.']['image.']);
+            $content .= $this->printMetaTag('twitter:image', $finalTwImageURL);
+        }
+
+        // creator
+        $content .= $this->printMetaTag(
+            'twitter:creator',
+            $this->escapeContent($meta['tw_creator'] ?: $pluginSettings['social.']['twitter.']['creator'])
+        );
+
+        return $content;
+    }
+
+    /**
+     * @param string $content
+     *
+     * @return string
+     */
+    protected function escapeContent($content)
+    {
+        return htmlentities(preg_replace('/\s\s+/', ' ', preg_replace('#<[^>]+>#', ' ', $content)));
+    }
+
+    /**
+     * @param string $name
+     * @param string $value
+     * @param bool $property
+     *
+     * @return string
+     */
+    protected function printMetaTag($name, $value, $property = false)
+    {
+        if (empty($value)) {
+            return '';
+        }
+
+        $propertyString = $property ? 'property' : 'name';
+
+        return '<meta ' . $propertyString . '="' . $name . '" content="' . $value . '" />';
+    }
+
+    /**
+     * @param string $table
+     * @param string $uid
+     *
+     * @return array
+     */
+    protected function getAllLanguagesFromItem($table, $uid)
+    {
+        $languageIds = [];
+
+        $pointerField =
+            isset($GLOBALS['TCA'][$table]['ctrl']['transOrigPointerField'])
+                ? $GLOBALS['TCA'][$table]['ctrl']['transOrigPointerField'] : 'l10n_parent';
+
+        $languageField =
+            isset($GLOBALS['TCA'][$table]['ctrl']['languageField']) ? $GLOBALS['TCA'][$table]['ctrl']['languageField']
+                : 'sys_language_uid';
+
+        $whereClause = '(' . $pointerField . ' = ' . $uid . ' OR uid = ' . $uid . ')';
+        $whereClause .= $GLOBALS['TSFE']->sys_page->enableFields($table);
+
+        $allItems = $GLOBALS['TYPO3_DB']->exec_SELECTgetRows($languageField, $table, $whereClause);
+
+        foreach ($allItems as $item) {
+            $languageIds[] = $item[$languageField];
+        }
+
+        return $languageIds;
+    }
+
+    /**
+     * @param string $table
+     * @param string $uid
+     *
+     * @return array
+     */
+    protected function getLanguageFromItem($table, $uid)
+    {
+        $whereClause = 'uid = ' . $uid;
+        $whereClause .= $GLOBALS['TSFE']->sys_page->enableFields($table);
+        $item = $GLOBALS['TYPO3_DB']->exec_SELECTgetRows('sys_language_uid', $table, $whereClause);
+
+        return $item[0]['sys_language_uid'];
+    }
+
+    /**
+     * Returns an image path for the given field and uid
+     *
+     * @param string $field
+     * @param string $uid
+     *
+     * @return string the image path
+     */
+    protected function getImagePath($field, $uid)
+    {
+        /** @var \TYPO3\CMS\Core\Resource\FileRepository $fileRepository */
+        $fileRepository = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance(
+            \TYPO3\CMS\Core\Resource\FileRepository::class
+        );
+        $fileObjects = $fileRepository->findByRelation(
+            'tx_csseo_domain_model_meta',
+            'tx_csseo_' . $field,
+            $uid
+        );
+
+        if ($fileObjects[0]) {
+            return $fileObjects[0]->getOriginalFile()->getPublicUrl();
+        }
+    }
+
+    /**
+     * Return an URL to the scaled image
+     *
+     * @param string $originalFile uid or path of the file
+     * @param array $imageSize width and height as keys
+     *
+     * @return string
+     */
+    protected function getScaledImagePath($originalFile, $imageSize)
+    {
+        $conf = [
+            'file' => $originalFile,
+            'file.' => [
+                'height' => $imageSize['height'],
+                'width' => $imageSize['width']
+            ]
+        ];
+        $imgUri = $this->cObj->cObjGetSingle('IMG_RESOURCE', $conf);
+        $conf = [
+            'parameter' => $imgUri,
+            'forceAbsoluteUrl' => 1
+        ];
+
+        return $this->cObj->typoLink_URL($conf);
+    }
 }

--- a/Classes/UserFunc/PageTitle.php
+++ b/Classes/UserFunc/PageTitle.php
@@ -33,9 +33,11 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
  * Render the page title tag with cs_seo settings
  *
  * Class PageTitle
+ *
  * @package Clickstorm\CsSeo\UserFunc
  */
-class PageTitle {
+class PageTitle
+{
 
     /**
      * @var TSFEUtility
@@ -45,6 +47,7 @@ class PageTitle {
     /**
      * @param string $oldTitle
      * @param array $content
+     *
      * @return string
      */
     public function render($oldTitle, $content)
@@ -65,16 +68,19 @@ class PageTitle {
 
     /**
      * Set the TSFE
+     *
      * @return void
      */
-    protected function initialize() {
+    protected function initialize()
+    {
         $this->TSFE = GeneralUtility::makeInstance(TSFEUtility::class, $GLOBALS['TSFE']->id);
     }
 
     /**
      * @return array
      */
-    protected function getPage() {
+    protected function getPage()
+    {
         return $this->TSFE->getPage();
     }
 }

--- a/Classes/UserFunc/PermalinkWizard.php
+++ b/Classes/UserFunc/PermalinkWizard.php
@@ -35,6 +35,7 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
  * Set the RealURL path segment if empty
  *
  * Class PageTitle
+ *
  * @package Clickstorm\CsSeo\UserFunc
  */
 class PermalinkWizard
@@ -104,7 +105,16 @@ class PermalinkWizard
         // Load the wizards javascript
         $baseUrl = ExtensionManagementUtility::extRelPath('cs_seo') . 'Resources/Public/JavaScript/';
         foreach ($javascriptFiles as $javascriptFile) {
-            $this->getPageRenderer()->addJsFile($baseUrl . $javascriptFile, 'text/javascript', $compress, false, '', false, '|', true);
+            $this->getPageRenderer()->addJsFile(
+                $baseUrl . $javascriptFile,
+                'text/javascript',
+                $compress,
+                false,
+                '',
+                false,
+                '|',
+                true
+            );
         }
     }
 
@@ -118,5 +128,4 @@ class PermalinkWizard
         }
         return $this->pageRenderer;
     }
-
 }

--- a/Classes/UserFunc/PreviewWizard.php
+++ b/Classes/UserFunc/PreviewWizard.php
@@ -39,6 +39,7 @@ use TYPO3\CMS\Frontend\Page\PageGenerator;
  * Google Search Results Preview
  *
  * Class PageTitle
+ *
  * @package Clickstorm\CsSeo\UserFunc
  */
 class PreviewWizard
@@ -112,15 +113,24 @@ class PreviewWizard
     protected function loadJavascript()
     {
         $compress = true;
-        $javascriptFiles = array(
+        $javascriptFiles = [
             'jquery.cs_seo.preview.js'
-        );
+        ];
         // Load jquery
         $this->getPageRenderer()->loadJquery();
         // Load the wizards javascript
         $baseUrl = ExtensionManagementUtility::extRelPath('cs_seo') . 'Resources/Public/JavaScript/';
         foreach ($javascriptFiles as $javascriptFile) {
-            $this->getPageRenderer()->addJsFile($baseUrl . $javascriptFile, 'text/javascript', $compress, false, '', false, '|', true);
+            $this->getPageRenderer()->addJsFile(
+                $baseUrl . $javascriptFile,
+                'text/javascript',
+                $compress,
+                false,
+                '',
+                false,
+                '|',
+                true
+            );
         }
     }
 
@@ -135,9 +145,9 @@ class PreviewWizard
     {
         // @todo Set to TRUE when finished
         $compress = false;
-        $cssFiles = array(
+        $cssFiles = [
             'Wizard.css'
-        );
+        ];
         $baseUrl = ExtensionManagementUtility::extRelPath('cs_seo') . 'Resources/Public/CSS/';
         // Load the wizards css
         foreach ($cssFiles as $cssFile) {
@@ -156,14 +166,17 @@ class PreviewWizard
     protected function getBodyContent($data, $table)
     {
         // template1
-	    /** @var StandaloneView $wizardView */
+        /** @var StandaloneView $wizardView */
         $wizardView = GeneralUtility::makeInstance(StandaloneView::class);
         $wizardView->setFormat('html');
-        $wizardView->setLayoutRootPaths([10 => ExtensionManagementUtility::extPath('cs_seo') . '/Resources/Private/Layouts/']);
-        $wizardView->setTemplatePathAndFilename(ExtensionManagementUtility::extPath('cs_seo') . 'Resources/Private/Templates/Wizard.html');
-        
-        if(strpos($data['uid'], 'NEW') === false) {
+        $wizardView->setLayoutRootPaths(
+            [10 => ExtensionManagementUtility::extPath('cs_seo') . '/Resources/Private/Layouts/']
+        );
+        $wizardView->setTemplatePathAndFilename(
+            ExtensionManagementUtility::extPath('cs_seo') . 'Resources/Private/Templates/Wizard.html'
+        );
 
+        if (strpos($data['uid'], 'NEW') === false) {
             // set pageID for TSSetup check
             $pageUid = ($table == 'pages') ? $data['uid'] : $data['pid'];
             $_GET['id'] = $pageUid;
@@ -173,42 +186,47 @@ class PreviewWizard
             $backendConfigurationManager = GeneralUtility::makeInstance(BackendConfigurationManager::class);
             $fullTS = $backendConfigurationManager->getTypoScriptSetup();
 
-            if(isset($fullTS['types.'][$this->typeNum]) || $GLOBALS['BE_USER']->workspace > 0) {
+            if (isset($fullTS['types.'][$this->typeNum]) || $GLOBALS['BE_USER']->workspace > 0) {
                 // render page title
                 $rootline = BackendUtility::BEgetRootLine($pageUid);
 
                 /** @var TSFEUtility $TSFEUtility */
-                $TSFEUtility =  GeneralUtility::makeInstance(TSFEUtility::class, $pageUid, $data['sys_language_uid']);
+                $TSFEUtility = GeneralUtility::makeInstance(TSFEUtility::class, $pageUid, $data['sys_language_uid']);
                 $fallback = [];
 
-                if(isset($GLOBALS['TSFE'])) {
-	                $siteTitle = $TSFEUtility->getSiteTitle();
-	                $pageTitleSeparator = $TSFEUtility->getPageTitleSeparator();
-	                $config = $TSFEUtility->getConfig();
+                if (isset($GLOBALS['TSFE'])) {
+                    $siteTitle = $TSFEUtility->getSiteTitle();
+                    $pageTitleSeparator = $TSFEUtility->getPageTitleSeparator();
+                    $config = $TSFEUtility->getConfig();
 
-	                if($table == 'pages' || $table == 'pages_language_overlay') {
-		                PageGenerator::generatePageTitle();
-		                $pageTitle = static::getPageRenderer()->getTitle();
-		                // get page path
-		                $path = $TSFEUtility->getPagePath();
-		                // TYPO3 8
-		                $urlScheme = is_array($data['url_scheme']) ? $data['url_scheme'][0] : $data['url_scheme'];
+                    if ($table == 'pages' || $table == 'pages_language_overlay') {
+                        PageGenerator::generatePageTitle();
+                        $pageTitle = static::getPageRenderer()->getTitle();
+                        // get page path
+                        $path = $TSFEUtility->getPagePath();
+                        // TYPO3 8
+                        $urlScheme = is_array($data['url_scheme']) ? $data['url_scheme'][0] : $data['url_scheme'];
 
-		                // check if path is absolute
-		                if (strpos($path, '://') !== false) {
-			                $path = '';
-		                }
+                        // check if path is absolute
+                        if (strpos($path, '://') !== false) {
+                            $path = '';
+                        }
                         $fallback['title'] = 'title';
                         $fallback['uid'] = 'uid';
                         $fallback['table'] = 'table';
-	                } else {
+                    } else {
                         $pageTSConfig = BackendUtility::getPagesTSconfig($pageUid);
 
                         // handle fallback
-                        if(isset($pageTSConfig['tx_csseo.'])) {
+                        if (isset($pageTSConfig['tx_csseo.'])) {
                             foreach ($pageTSConfig['tx_csseo.'] as $key => $settings) {
-                                if(is_string($settings)) {
-                                    if($settings == $data['tablenames'] && isset($pageTSConfig['tx_csseo.'][$key . '.']['fallback.'])) {
+                                if (is_string($settings)) {
+                                    if ($settings == $data['tablenames']
+                                        && isset(
+                                            $pageTSConfig['tx_csseo.'][$key
+                                            . '.']['fallback.']
+                                        )
+                                    ) {
                                         $fallback = $pageTSConfig['tx_csseo.'][$key . '.']['fallback.'];
                                         break;
                                     }
@@ -216,7 +234,7 @@ class PreviewWizard
                             }
                         }
 
-                        if($fallback) {
+                        if ($fallback) {
                             $res = $GLOBALS['TYPO3_DB']->exec_SELECTgetRows(
                                 '*',
                                 $data['tablenames'],
@@ -228,7 +246,7 @@ class PreviewWizard
                             $row = $res[0];
 
                             foreach ($fallback as $seoField => $fallbackField) {
-                                if(empty($data[$seoField])) {
+                                if (empty($data[$seoField])) {
                                     $data[$seoField] = $row[$fallbackField];
                                 }
                             }
@@ -237,24 +255,26 @@ class PreviewWizard
                             $fallback['table'] = $data['tablenames'];
                         }
 
-		                $pageTitle = $TSFEUtility->getFinalTitle($data['title'], $data['title_only']);
-		                $path = '';
-		                $urlScheme = 'http://';
-	                }
+                        $pageTitle = $TSFEUtility->getFinalTitle($data['title'], $data['title_only']);
+                        $path = '';
+                        $urlScheme = 'http://';
+                    }
 
-	                $wizardView->assignMultiple([
-		                'config' => $config,
-		                'data' => $data,
-                        'domain' => BackendUtility::firstDomainRecord($rootline),
-                        'fallback' => $fallback,
-		                'pageTitle' => $pageTitle,
-		                'pageTitleSeparator' => $pageTitleSeparator,
-		                'path' => $path,
-		                'siteTitle' => $siteTitle,
-		                'urlScheme' => $urlScheme
-	                ]);
-	            } else {
-	                $wizardView->assign('error', 'no_tsfe');
+                    $wizardView->assignMultiple(
+                        [
+                            'config' => $config,
+                            'data' => $data,
+                            'domain' => BackendUtility::firstDomainRecord($rootline),
+                            'fallback' => $fallback,
+                            'pageTitle' => $pageTitle,
+                            'pageTitleSeparator' => $pageTitleSeparator,
+                            'path' => $path,
+                            'siteTitle' => $siteTitle,
+                            'urlScheme' => $urlScheme
+                        ]
+                    );
+                } else {
+                    $wizardView->assign('error', 'no_tsfe');
                 }
             } else {
                 $wizardView->assign('error', 'no_ts');

--- a/Classes/UserFunc/StructuredData.php
+++ b/Classes/UserFunc/StructuredData.php
@@ -46,11 +46,11 @@ class StructuredData
 
     public function __construct()
     {
-        $this->tsfeUtility = GeneralUtility::makeInstance(\Clickstorm\CsSeo\Utility\TSFEUtility::class, $GLOBALS['TSFE']->id);
-
+        $this->tsfeUtility =
+            GeneralUtility::makeInstance(\Clickstorm\CsSeo\Utility\TSFEUtility::class, $GLOBALS['TSFE']->id);
     }
 
-     /**
+    /**
      * Returns the json for the siteSearch
      *
      * @return bool|string siteSearch
@@ -63,7 +63,7 @@ class StructuredData
         $typoLinkConf = [
             'parameter' => $conf['userFunc.']['pid'],
             'forceAbsoluteUrl' => 1,
-            'additionalParams' => '&'.$conf['userFunc.']['searchterm'].'='
+            'additionalParams' => '&' . $conf['userFunc.']['searchterm'] . '='
         ];
 
         $siteSearchUrl = $cObject->typoLink_URL($typoLinkConf);
@@ -71,27 +71,27 @@ class StructuredData
         $siteSearch = [
             '@context' => 'http://schema.org',
             '@type' => 'WebSite',
-            'url' => $homepage.'/',
+            'url' => $homepage . '/',
             'potentialAction' => [
                 '@type' => 'SearchAction',
-                'target' => $siteSearchUrl.'{search_term_string}',
+                'target' => $siteSearchUrl . '{search_term_string}',
                 'query-input' => 'required name=search_term_string',
             ],
         ];
 
         return $this->wrapWithLd(json_encode($siteSearch));
-
     }
 
     /**
      * Wraps $content with Json declaration
      *
      * @param $content
+     *
      * @return string
      */
     protected function wrapWithLd($content)
     {
-        return '<script type="application/ld+json">'.$content.'</script>';
+        return '<script type="application/ld+json">' . $content . '</script>';
     }
 
     /**
@@ -99,6 +99,7 @@ class StructuredData
      *
      * @param $conf
      * @param $content
+     *
      * @return string
      */
     public function getBreadcrumb($conf, $content)
@@ -109,7 +110,7 @@ class StructuredData
 
         $cObject = GeneralUtility::makeInstance(ContentObjectRenderer::class);
 
-        $siteLinks = array();
+        $siteLinks = [];
 
         foreach (array_reverse($rootline) as $index => $page) {
             $typoLinkConf = [
@@ -127,13 +128,12 @@ class StructuredData
             ];
         }
 
-        $breadcrumbItems = array();
+        $breadcrumbItems = [];
         // remove the last element because it's the current page itself and this should NOT be included
         // into the structured breadcrumb
         array_pop($siteLinks);
 
         foreach ($siteLinks as $index => $pInfo) {
-
             $breadcrumbItems[] = [
                 '@type' => 'ListItem',
                 'position' => $index + 1,

--- a/Classes/Utility/ConfigurationUtility.php
+++ b/Classes/Utility/ConfigurationUtility.php
@@ -32,32 +32,36 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
  * Get Extension Configuration
  *
  * Class ConfigurationUtility
+ *
  * @package Clickstorm\CsSeo\Utility
  */
-class ConfigurationUtility {
+class ConfigurationUtility
+{
 
-	/**
-	 * Get the configuration from the extension manager
-	 *
-	 * @return array
-	 */
-	public static function getEmConfiguration() {
-		$conf = unserialize($GLOBALS['TYPO3_CONF_VARS']['EXT']['extConf']['cs_seo']);
-		return is_array($conf) ? $conf : [];
-	}
+    /**
+     * Get the configuration from the extension manager
+     *
+     * @return array
+     */
+    public static function getEmConfiguration()
+    {
+        $conf = unserialize($GLOBALS['TYPO3_CONF_VARS']['EXT']['extConf']['cs_seo']);
+        return is_array($conf) ? $conf : [];
+    }
 
     /**
      * return the settings to extend records
      *
      * @return array
      */
-    public static function getPageTSconfig() {
+    public static function getPageTSconfig()
+    {
         $extConf = self::getEmConfiguration();
         $tsConfigPid = $extConf['tsConfigPid'] ?: 1;
 
         $rootLine = \TYPO3\CMS\Backend\Utility\BackendUtility::BEgetRootLine($tsConfigPid, '', true);
         $pageTSconfig = \TYPO3\CMS\Backend\Utility\BackendUtility::getPagesTSconfig($tsConfigPid, $rootLine);
-        return $pageTSconfig['tx_csseo.']?:[];
+        return $pageTSconfig['tx_csseo.'] ?: [];
     }
 
     /**
@@ -65,12 +69,13 @@ class ConfigurationUtility {
      *
      * @return array
      */
-    public static function getTablesToExtend() {
+    public static function getTablesToExtend()
+    {
         $pageTSconfig = self::getPageTSconfig();
         $tables = [];
-        if($pageTSconfig) {
+        if ($pageTSconfig) {
             foreach ($pageTSconfig as $table) {
-                if(is_string($table)) {
+                if (is_string($table)) {
                     $tables[] = $table;
                 }
             }
@@ -79,17 +84,18 @@ class ConfigurationUtility {
         return $tables;
     }
 
-	/**
-	 * return the allowed doktypes of pages for evaluation
-	 *
-	 * @return array
-	 */
-	public static function getEvaluationDoktypes() {
-		$allowedDoktypes = [1];
-		$extConf = self::getEmConfiguration();
-		if($extConf['evaluationDoktypes']) {
-			$allowedDoktypes = GeneralUtility::trimExplode(',', $extConf['evaluationDoktypes']);
-		}
-		return $allowedDoktypes;
-	}
+    /**
+     * return the allowed doktypes of pages for evaluation
+     *
+     * @return array
+     */
+    public static function getEvaluationDoktypes()
+    {
+        $allowedDoktypes = [1];
+        $extConf = self::getEmConfiguration();
+        if ($extConf['evaluationDoktypes']) {
+            $allowedDoktypes = GeneralUtility::trimExplode(',', $extConf['evaluationDoktypes']);
+        }
+        return $allowedDoktypes;
+    }
 }

--- a/Classes/Utility/DatabaseUtility.php
+++ b/Classes/Utility/DatabaseUtility.php
@@ -36,23 +36,29 @@ use TYPO3\CMS\Backend\Utility\BackendUtility;
  * Access to the Database
  *
  * Class DatabaseUtility
+ *
  * @package Clickstorm\CsSeo\Utility
  */
-class DatabaseUtility {
+class DatabaseUtility
+{
 
     /**
      * @param $table
+     *
      * @return array
      */
-    public static function getRecords($table) {
+    public static function getRecords($table)
+    {
         $items = [];
 
         $res = self::getDatabaseConnection()->exec_SELECTquery(
             '*',
             $table,
             '1=1 ' . BackendUtility::BEenableFields($table),
-	        '',
-	        $GLOBALS['TCA'][$table]['ctrl']['tstamp'] ? $GLOBALS['TCA'][$table]['ctrl']['tstamp'] . ' ' . QueryInterface::ORDER_ASCENDING : ''
+            '',
+            $GLOBALS['TCA'][$table]['ctrl']['tstamp'] ? $GLOBALS['TCA'][$table]['ctrl']['tstamp']
+                . ' '
+                . QueryInterface::ORDER_ASCENDING : ''
         );
         while ($row = self::getDatabaseConnection()->sql_fetch_assoc($res)) {
             $items[$row['uid']] = $row[$GLOBALS['TCA'][$table]['ctrl']['label']];

--- a/Classes/Utility/TSFEUtility.php
+++ b/Classes/Utility/TSFEUtility.php
@@ -39,9 +39,11 @@ use TYPO3\CMS\Extbase\Utility\LocalizationUtility;
  * own TSFE to render TSFE in the backend
  *
  * Class TSFEUtility
+ *
  * @package Clickstorm\CsSeo\Utility
  */
-class TSFEUtility {
+class TSFEUtility
+{
 
     /**
      * @var int
@@ -63,10 +65,10 @@ class TSFEUtility {
      */
     protected $typeNum;
 
-	/**
-	 * @var int
-	 */
-	protected $lang;
+    /**
+     * @var int
+     */
+    protected $lang;
 
     /**
      * @var array
@@ -75,18 +77,25 @@ class TSFEUtility {
 
     /**
      * TSFEUtility constructor.
+     *
      * @param int $pageUid
      * @param int $lang
      * @param int $typeNum
      */
-    public function __construct($pageUid, $lang = 0, $typeNum = 654) {
+    public function __construct($pageUid, $lang = 0, $typeNum = 654)
+    {
         $this->pageUid = $pageUid;
         $this->lang = is_array($lang) ? array_shift($lang) : $lang;
-	    $this->typeNum = $typeNum;
+        $this->typeNum = $typeNum;
 
         $environmentService = GeneralUtility::makeInstance(\TYPO3\CMS\Extbase\Service\EnvironmentService::class);
 
-        if(!isset($GLOBALS['TSFE']) || ($environmentService->isEnvironmentInBackendMode() && !($GLOBALS['TSFE'] instanceof TypoScriptFrontendController))) {
+        if (!isset($GLOBALS['TSFE'])
+            || ($environmentService->isEnvironmentInBackendMode()
+                && !($GLOBALS['TSFE']
+                    instanceof
+                    TypoScriptFrontendController))
+        ) {
             $this->initTSFE();
         }
         $this->config = $GLOBALS['TSFE']->tmpl->setup['config.'];
@@ -95,15 +104,17 @@ class TSFEUtility {
     /**
      * @return string
      */
-    public function getPagePath() {
-    	$params = ($this->lang > 0) ? ['L' => $this->lang] : [];
+    public function getPagePath()
+    {
+        $params = ($this->lang > 0) ? ['L' => $this->lang] : [];
         return $GLOBALS['TSFE']->cObj->getTypoLink_URL($this->pageUid, $params);
     }
 
     /**
      * @return array
      */
-    public function getPage() {
+    public function getPage()
+    {
         return $GLOBALS['TSFE']->page;
     }
 
@@ -111,34 +122,41 @@ class TSFEUtility {
     /**
      * @return array
      */
-    public function getConfig() {
+    public function getConfig()
+    {
         return $this->config;
     }
 
     /**
      * @return array
      */
-    public function getPageTitleFirst() {
+    public function getPageTitleFirst()
+    {
         return $this->config['pageTitleFirst'];
     }
 
     /**
      * @return string
      */
-    public function getPageTitleSeparator() {
-        return $GLOBALS['TSFE']->cObj->stdWrap($this->config['pageTitleSeparator'], $this->config['pageTitleSeparator.']);
+    public function getPageTitleSeparator()
+    {
+        return $GLOBALS['TSFE']->cObj->stdWrap(
+            $this->config['pageTitleSeparator'],
+            $this->config['pageTitleSeparator.']
+        );
     }
 
     /**
      * @return string
      */
-    public function getSiteTitle() {
-	    $sitetitle = $GLOBALS['TSFE']->tmpl->setup['plugin.']['tx_csseo.']['sitetitle'];
-	    if($sitetitle) {
-		    return $GLOBALS['TSFE']->sL($sitetitle);
-	    } else {
-		    return $GLOBALS['TSFE']->tmpl->setup['sitetitle'];
-	    }
+    public function getSiteTitle()
+    {
+        $sitetitle = $GLOBALS['TSFE']->tmpl->setup['plugin.']['tx_csseo.']['sitetitle'];
+        if ($sitetitle) {
+            return $GLOBALS['TSFE']->sL($sitetitle);
+        } else {
+            return $GLOBALS['TSFE']->tmpl->setup['sitetitle'];
+        }
     }
 
     /**
@@ -147,16 +165,17 @@ class TSFEUtility {
      *
      * @return string
      */
-    public function getFinalTitle($title, $titleOnly = false) {
-    	if($titleOnly) {
-	        return $title;
-    	}
+    public function getFinalTitle($title, $titleOnly = false)
+    {
+        if ($titleOnly) {
+            return $title;
+        }
 
         $siteTitle = $this->getSiteTitle();
         $pageTitleFirst = $this->getConfig()['pageTitleFirst'];
         $pageTitleSeparator = $this->getPageTitleSeparator();
 
-        if($pageTitleFirst) {
+        if ($pageTitleFirst) {
             $title .= $pageTitleSeparator . $siteTitle;
         } else {
             $title = $siteTitle . $pageTitleSeparator . $title;
@@ -169,20 +188,25 @@ class TSFEUtility {
      *
      * @return void
      */
-    protected function initTSFE() {
+    protected function initTSFE()
+    {
         try {
-	        GeneralUtility::_GETset($this->lang, 'L');
+            GeneralUtility::_GETset($this->lang, 'L');
             if (!is_object($GLOBALS['TT'])) {
                 $GLOBALS['TT'] = new NullTimeTracker;
                 $GLOBALS['TT']->start();
             }
 
-            $GLOBALS['TSFE'] = GeneralUtility::makeInstance(TypoScriptFrontendController::class,
-                $GLOBALS['TYPO3_CONF_VARS'], $this->pageUid, $this->typeNum);
+            $GLOBALS['TSFE'] = GeneralUtility::makeInstance(
+                TypoScriptFrontendController::class,
+                $GLOBALS['TYPO3_CONF_VARS'],
+                $this->pageUid,
+                $this->typeNum
+            );
 
             $GLOBALS['TSFE']->config = [];
             $GLOBALS['TSFE']->forceTemplateParsing = true;
-	        $GLOBALS['TSFE']->showHiddenPages = true;
+            $GLOBALS['TSFE']->showHiddenPages = true;
 
             $GLOBALS['TSFE']->connectToDB();
             $GLOBALS['TSFE']->initFEuser();
@@ -197,18 +221,19 @@ class TSFEUtility {
             }
 
             $GLOBALS['TSFE']->getConfigArray();
-	        $GLOBALS['TSFE']->settingLanguage();
+            $GLOBALS['TSFE']->settingLanguage();
         } catch (\Exception $e) {
-	        /** @var FlashMessage $message */
-	        $message = GeneralUtility::makeInstance(FlashMessage::class,
-		        $e->getMessage(),
-		        LocalizationUtility::translate('error.no_ts', 'cs_seo'),
-		        FlashMessage::ERROR
-	        );
-	        /** @var FlashMessageService $flashMessageService */
-	        $flashMessageService = GeneralUtility::makeInstance(FlashMessageService::class);
-	        $messageQueue = $flashMessageService->getMessageQueueByIdentifier('cs_seo');
-	        $messageQueue->addMessage($message);
+            /** @var FlashMessage $message */
+            $message = GeneralUtility::makeInstance(
+                FlashMessage::class,
+                $e->getMessage(),
+                LocalizationUtility::translate('error.no_ts', 'cs_seo'),
+                FlashMessage::ERROR
+            );
+            /** @var FlashMessageService $flashMessageService */
+            $flashMessageService = GeneralUtility::makeInstance(FlashMessageService::class);
+            $messageQueue = $flashMessageService->getMessageQueueByIdentifier('cs_seo');
+            $messageQueue->addMessage($message);
         }
     }
 }

--- a/Classes/ViewHelpers/ExplodeViewHelper.php
+++ b/Classes/ViewHelpers/ExplodeViewHelper.php
@@ -31,17 +31,20 @@ use TYPO3\CMS\Fluid\Core\ViewHelper\AbstractViewHelper;
 
 /**
  * Class GetValueViewHelper
+ *
  * @package Clickstorm\CsSeo\ViewHelpers
  */
-class ExplodeViewHelper extends AbstractViewHelper {
+class ExplodeViewHelper extends AbstractViewHelper
+{
 
-	/**
-	 * @param string $delimiter
-	 * @param string $string
-	 * @return array
-	 */
-	public function render($delimiter = ',', $string = '') {
-		return GeneralUtility::trimExplode($delimiter, $string);
-	}
-
+    /**
+     * @param string $delimiter
+     * @param string $string
+     *
+     * @return array
+     */
+    public function render($delimiter = ',', $string = '')
+    {
+        return GeneralUtility::trimExplode($delimiter, $string);
+    }
 }

--- a/Classes/ViewHelpers/GetValueViewHelper.php
+++ b/Classes/ViewHelpers/GetValueViewHelper.php
@@ -30,17 +30,20 @@ use TYPO3\CMS\Fluid\Core\ViewHelper\AbstractViewHelper;
 
 /**
  * Class GetValueViewHelper
+ *
  * @package Clickstorm\CsSeo\ViewHelpers
  */
-class GetValueViewHelper extends AbstractViewHelper {
+class GetValueViewHelper extends AbstractViewHelper
+{
 
-	/**
-	 * @param array $array
-	 * @param string $key
-	 * @return mixed
-	 */
-	public function render($array, $key) {
-		return $array[$key];
-	}
-
+    /**
+     * @param array $array
+     * @param string $key
+     *
+     * @return mixed
+     */
+    public function render($array, $key)
+    {
+        return $array[$key];
+    }
 }

--- a/Classes/ViewHelpers/ImplodeViewHelper.php
+++ b/Classes/ViewHelpers/ImplodeViewHelper.php
@@ -30,17 +30,20 @@ use TYPO3\CMS\Fluid\Core\ViewHelper\AbstractViewHelper;
 
 /**
  * Class GetValueViewHelper
+ *
  * @package Clickstorm\CsSeo\ViewHelpers
  */
-class ImplodeViewHelper extends AbstractViewHelper {
+class ImplodeViewHelper extends AbstractViewHelper
+{
 
-	/**
-	 * @param string $glue
-	 * @param array $pieces
-	 * @return string
-	 */
-	public function render($glue = ',', $pieces = []) {
-		return implode($glue, $pieces);
-	}
-
+    /**
+     * @param string $glue
+     * @param array $pieces
+     *
+     * @return string
+     */
+    public function render($glue = ',', $pieces = [])
+    {
+        return implode($glue, $pieces);
+    }
 }

--- a/Tests/Build/UnitTests.xml
+++ b/Tests/Build/UnitTests.xml
@@ -1,23 +1,23 @@
 <phpunit backupGlobals="false"
-	backupStaticAttributes="false"
-	bootstrap="../../../../../typo3/sysext/core/Build/UnitTestsBootstrap.php"
-	colors="true"
-	convertErrorsToExceptions="true"
-	convertWarningsToExceptions="true"
-	forceCoversAnnotation="false"
-	processIsolation="false"
-	stopOnError="false"
-	stopOnFailure="false"
-	stopOnIncomplete="false"
-	stopOnSkipped="false"
-	strict="false"
-	verbose="false">
+         backupStaticAttributes="false"
+         bootstrap="../../../../../typo3/sysext/core/Build/UnitTestsBootstrap.php"
+         colors="true"
+         convertErrorsToExceptions="true"
+         convertWarningsToExceptions="true"
+         forceCoversAnnotation="false"
+         processIsolation="false"
+         stopOnError="false"
+         stopOnFailure="false"
+         stopOnIncomplete="false"
+         stopOnSkipped="false"
+         strict="false"
+         verbose="false">
 
-	<testsuites>
-		<testsuite name="EXT:cs_seo test">
-			<directory>../Unit/</directory>
-		</testsuite>
+    <testsuites>
+        <testsuite name="EXT:cs_seo test">
+            <directory>../Unit/</directory>
+        </testsuite>
 
-	</testsuites>
+    </testsuites>
 
 </phpunit>

--- a/Tests/Unit/Evaluation/DescriptionEvaluatorTest.php
+++ b/Tests/Unit/Evaluation/DescriptionEvaluatorTest.php
@@ -32,116 +32,116 @@ use TYPO3\CMS\Core\Tests\UnitTestCase;
 /**
  * @package cs_seo
  */
-
 class DescriptionEvaluatorTest extends UnitTestCase
 {
 
-	/**
-	 * @var DescriptionEvaluator
-	 */
-	protected $generalEvaluationMock;
+    /**
+     * @var DescriptionEvaluator
+     */
+    protected $generalEvaluationMock;
 
-	/**
-	 * @var int
-	 */
-	protected $min = 140;
+    /**
+     * @var int
+     */
+    protected $min = 140;
 
-	/**
-	 * @var int
-	 */
-	protected $max = 160;
+    /**
+     * @var int
+     */
+    protected $max = 160;
 
 
-	/**
-	 * @return void
-	 */
-	public function setUp()
-	{
-		$this->generalEvaluationMock = $this->getAccessibleMock(DescriptionEvaluator::class, ['dummy'], [new \DOMDocument()]);
-		$extConf = [
-			'minDescription' => $this->min,
-			'maxDescription' => $this->max
-		];
-		$GLOBALS['TYPO3_CONF_VARS']['EXT']['extConf']['cs_seo'] = serialize($extConf);
-		$GLOBALS['TYPO3_CONF_VARS']['SYS']['t3lib_cs_utils'] = '';
+    /**
+     * @return void
+     */
+    public function setUp()
+    {
+        $this->generalEvaluationMock =
+            $this->getAccessibleMock(DescriptionEvaluator::class, ['dummy'], [new \DOMDocument()]);
+        $extConf = [
+            'minDescription' => $this->min,
+            'maxDescription' => $this->max
+        ];
+        $GLOBALS['TYPO3_CONF_VARS']['EXT']['extConf']['cs_seo'] = serialize($extConf);
+        $GLOBALS['TYPO3_CONF_VARS']['SYS']['t3lib_cs_utils'] = '';
+    }
 
-	}
+    /**
+     * @return void
+     */
+    public function tearDown()
+    {
+        unset($this->generalEvaluationMock);
+        unset($GLOBALS['TYPO3_CONF_VARS']['EXT']['extConf']['cs_seo']);
+        unset($GLOBALS['TYPO3_CONF_VARS']['SYS']['t3lib_cs_utils']);
+    }
 
-	/**
-	 * @return void
-	 */
-	public function tearDown()
-	{
-		unset($this->generalEvaluationMock);
-		unset($GLOBALS['TYPO3_CONF_VARS']['EXT']['extConf']['cs_seo']);
-		unset($GLOBALS['TYPO3_CONF_VARS']['SYS']['t3lib_cs_utils']);
-	}
+    /**
+     * evaluateTest
+     *
+     * @param string $html
+     * @param mixed $expectedResult
+     *
+     * @dataProvider evaluateTestDataProvider
+     * @return void
+     * @test
+     */
+    public function evaluateTest($html, $expectedResult)
+    {
+        $domDocument = new \DOMDocument();
+        @$domDocument->loadHTML($html);
+        $this->generalEvaluationMock->setDomDocument($domDocument);
+        $result = $this->generalEvaluationMock->evaluate();
 
-	/**
-	 * evaluateTest
-	 *
-	 * @param string $html
-	 * @param mixed $expectedResult
-	 * @dataProvider evaluateTestDataProvider
-	 * @return void
-	 * @test
-	 */
-	public function evaluateTest($html, $expectedResult) {
-		$domDocument = new \DOMDocument();
-		@$domDocument->loadHTML($html);
-		$this->generalEvaluationMock->setDomDocument($domDocument);
-		$result = $this->generalEvaluationMock->evaluate();
+        ksort($expectedResult);
+        ksort($result);
 
-		ksort($expectedResult);
-		ksort($result);
+        $this->assertEquals(json_encode($expectedResult), json_encode($result));
+    }
 
-		$this->assertEquals(json_encode($expectedResult), json_encode($result));
-	}
-
-	/**
-	 * Dataprovider evaluateTest()
-	 *
-	 * @return array
-	 */
-	public function evaluateTestDataProvider()
-	{
-		return [
-			'zero description' => [
-				'',
-				[
-					'count' => 0,
-					'state' => DescriptionEvaluator::STATE_RED
-				]
-			],
-			'short decription' => [
-				'<meta name="description" content="' . str_repeat('.', $this->min-1) . '" />',
-				[
-					'count' => $this->min-1,
-					'state' => DescriptionEvaluator::STATE_YELLOW,
-				]
-			],
-			'min good decription' => [
-				'<meta name="description" content="' . str_repeat('.', $this->min) . '" />',
-				[
-					'count' => $this->min,
-					'state' => DescriptionEvaluator::STATE_GREEN,
-				]
-			],
-			'max good decription' => [
-				'<meta name="description" content="' . str_repeat('.', $this->max) . '" />',
-				[
-					'count' => $this->max,
-					'state' => DescriptionEvaluator::STATE_GREEN,
-				]
-			],
-			'long decription' => [
-				'<meta name="description" content="' . str_repeat('.', $this->max+1) . '" />',
-				[
-					'count' => $this->max+1,
-					'state' => DescriptionEvaluator::STATE_YELLOW,
-				]
-			]
-		];
-	}
-
+    /**
+     * Dataprovider evaluateTest()
+     *
+     * @return array
+     */
+    public function evaluateTestDataProvider()
+    {
+        return [
+            'zero description' => [
+                '',
+                [
+                    'count' => 0,
+                    'state' => DescriptionEvaluator::STATE_RED
+                ]
+            ],
+            'short decription' => [
+                '<meta name="description" content="' . str_repeat('.', $this->min - 1) . '" />',
+                [
+                    'count' => $this->min - 1,
+                    'state' => DescriptionEvaluator::STATE_YELLOW,
+                ]
+            ],
+            'min good decription' => [
+                '<meta name="description" content="' . str_repeat('.', $this->min) . '" />',
+                [
+                    'count' => $this->min,
+                    'state' => DescriptionEvaluator::STATE_GREEN,
+                ]
+            ],
+            'max good decription' => [
+                '<meta name="description" content="' . str_repeat('.', $this->max) . '" />',
+                [
+                    'count' => $this->max,
+                    'state' => DescriptionEvaluator::STATE_GREEN,
+                ]
+            ],
+            'long decription' => [
+                '<meta name="description" content="' . str_repeat('.', $this->max + 1) . '" />',
+                [
+                    'count' => $this->max + 1,
+                    'state' => DescriptionEvaluator::STATE_YELLOW,
+                ]
+            ]
+        ];
+    }
 }

--- a/Tests/Unit/Evaluation/H1EvaluatorTest.php
+++ b/Tests/Unit/Evaluation/H1EvaluatorTest.php
@@ -32,82 +32,82 @@ use TYPO3\CMS\Core\Tests\UnitTestCase;
 /**
  * @package cs_seo
  */
-
 class H1EvaluatorTest extends UnitTestCase
 {
 
-	/**
-	 * @var H1Evaluator
-	 */
-	protected $generalEvaluationMock;
+    /**
+     * @var H1Evaluator
+     */
+    protected $generalEvaluationMock;
 
-	/**
-	 * @return void
-	 */
-	public function setUp()
-	{
-		$this->generalEvaluationMock = $this->getAccessibleMock(H1Evaluator::class, ['dummy'], [new \DOMDocument()]);
-	}
+    /**
+     * @return void
+     */
+    public function setUp()
+    {
+        $this->generalEvaluationMock = $this->getAccessibleMock(H1Evaluator::class, ['dummy'], [new \DOMDocument()]);
+    }
 
-	/**
-	 * @return void
-	 */
-	public function tearDown()
-	{
-		unset($this->generalEvaluationMock);
-	}
+    /**
+     * @return void
+     */
+    public function tearDown()
+    {
+        unset($this->generalEvaluationMock);
+    }
 
-	/**
-	 * htmlspecialcharsOnArray Test
-	 *
-	 * @param string $html
-	 * @param mixed $expectedResult
-	 * @dataProvider evaluateTestDataProvider
-	 * @return void
-	 * @test
-	 */
-	public function evaluateTest($html, $expectedResult) {
-		$domDocument = new \DOMDocument();
-		@$domDocument->loadHTML($html);
-		$this->generalEvaluationMock->setDomDocument($domDocument);
-		$result = $this->generalEvaluationMock->evaluate();
+    /**
+     * htmlspecialcharsOnArray Test
+     *
+     * @param string $html
+     * @param mixed $expectedResult
+     *
+     * @dataProvider evaluateTestDataProvider
+     * @return void
+     * @test
+     */
+    public function evaluateTest($html, $expectedResult)
+    {
+        $domDocument = new \DOMDocument();
+        @$domDocument->loadHTML($html);
+        $this->generalEvaluationMock->setDomDocument($domDocument);
+        $result = $this->generalEvaluationMock->evaluate();
 
-		ksort($expectedResult);
-		ksort($result);
+        ksort($expectedResult);
+        ksort($result);
 
-		$this->assertEquals($expectedResult, $result);
-	}
+        $this->assertEquals($expectedResult, $result);
+    }
 
-	/**
-	 * Dataprovider evaluateTest()
-	 *
-	 * @return array
-	 */
-	public function evaluateTestDataProvider()
-	{
-		return [
-			'zero h1' => [
-				'',
-				[
-					'count' => 0,
-					'state' => H1Evaluator::STATE_RED
-				]
-			],
-			'one h1' => [
-				'<html><body><h1>Headline One</h1></body></html>',
-				[
-					'count' => 1,
-					'state' => H1Evaluator::STATE_GREEN,
-				]
-			],
-			'two h1' => [
-				'<h1>Headline One</h1><h1>Headline Two</h1>',
-				[
-					'state' => H1Evaluator::STATE_RED,
-					'count' => 2
-				]
-			],
-		];
-	}
-
+    /**
+     * Dataprovider evaluateTest()
+     *
+     * @return array
+     */
+    public function evaluateTestDataProvider()
+    {
+        return [
+            'zero h1' => [
+                '',
+                [
+                    'count' => 0,
+                    'state' => H1Evaluator::STATE_RED
+                ]
+            ],
+            'one h1' => [
+                '<html><body><h1>Headline One</h1></body></html>',
+                [
+                    'count' => 1,
+                    'state' => H1Evaluator::STATE_GREEN,
+                ]
+            ],
+            'two h1' => [
+                '<h1>Headline One</h1><h1>Headline Two</h1>',
+                [
+                    'state' => H1Evaluator::STATE_RED,
+                    'count' => 2
+                ]
+            ],
+        ];
+    }
 }

--- a/Tests/Unit/Evaluation/H2EvaluatorTest.php
+++ b/Tests/Unit/Evaluation/H2EvaluatorTest.php
@@ -32,106 +32,106 @@ use TYPO3\CMS\Core\Tests\UnitTestCase;
 /**
  * @package cs_seo
  */
-
 class H2EvaluatorTest extends UnitTestCase
 {
 
-	/**
-	 * @var H2Evaluator
-	 */
-	protected $generalEvaluationMock;
+    /**
+     * @var H2Evaluator
+     */
+    protected $generalEvaluationMock;
 
-	/**
-	 * @var int
-	 */
-	protected $max = 6;
+    /**
+     * @var int
+     */
+    protected $max = 6;
 
-	/**
-	 * @return void
-	 */
-	public function setUp()
-	{
-		$this->generalEvaluationMock = $this->getAccessibleMock(H2Evaluator::class, ['dummy'], [new \DOMDocument()]);
-		$extConf = [
-			'maxH2' => $this->max
-		];
-		$GLOBALS['TYPO3_CONF_VARS']['EXT']['extConf']['cs_seo'] = serialize($extConf);
-	}
+    /**
+     * @return void
+     */
+    public function setUp()
+    {
+        $this->generalEvaluationMock = $this->getAccessibleMock(H2Evaluator::class, ['dummy'], [new \DOMDocument()]);
+        $extConf = [
+            'maxH2' => $this->max
+        ];
+        $GLOBALS['TYPO3_CONF_VARS']['EXT']['extConf']['cs_seo'] = serialize($extConf);
+    }
 
-	/**
-	 * @return void
-	 */
-	public function tearDown()
-	{
-		unset($this->generalEvaluationMock);
-		unset($GLOBALS['TYPO3_CONF_VARS']['EXT']['extConf']['cs_seo']);
-	}
+    /**
+     * @return void
+     */
+    public function tearDown()
+    {
+        unset($this->generalEvaluationMock);
+        unset($GLOBALS['TYPO3_CONF_VARS']['EXT']['extConf']['cs_seo']);
+    }
 
-	/**
-	 * htmlspecialcharsOnArray Test
-	 *
-	 * @param string $html
-	 * @param mixed $expectedResult
-	 * @dataProvider evaluateTestDataProvider
-	 * @return void
-	 * @test
-	 */
-	public function evaluateTest($html, $expectedResult) {
-		$domDocument = new \DOMDocument();
-		@$domDocument->loadHTML($html);
-		$this->generalEvaluationMock->setDomDocument($domDocument);
-		$result = $this->generalEvaluationMock->evaluate();
+    /**
+     * htmlspecialcharsOnArray Test
+     *
+     * @param string $html
+     * @param mixed $expectedResult
+     *
+     * @dataProvider evaluateTestDataProvider
+     * @return void
+     * @test
+     */
+    public function evaluateTest($html, $expectedResult)
+    {
+        $domDocument = new \DOMDocument();
+        @$domDocument->loadHTML($html);
+        $this->generalEvaluationMock->setDomDocument($domDocument);
+        $result = $this->generalEvaluationMock->evaluate();
 
-		ksort($expectedResult);
-		ksort($result);
+        ksort($expectedResult);
+        ksort($result);
 
-		$this->assertEquals(json_encode($expectedResult), json_encode($result));
-	}
+        $this->assertEquals(json_encode($expectedResult), json_encode($result));
+    }
 
-	/**
-	 * Dataprovider evaluateTest()
-	 *
-	 * @return array
-	 */
-	public function evaluateTestDataProvider()
-	{
-		return [
-			'zero h2' => [
-				'',
-				[
-					'count' => 0,
-					'state' => H2Evaluator::STATE_RED
-				]
-			],
-			'one h2' => [
-				'<html><body><h2>Headline One</h2></body></html>',
-				[
-					'count' => 1,
-					'state' => H2Evaluator::STATE_GREEN,
-				]
-			],
-			'two h2' => [
-				'<h2>Headline One</h2><h2>Headline Two</h2>',
-				[
-					'state' => H2Evaluator::STATE_GREEN,
-					'count' => 2
-				]
-			],
-			'six h2' => [
-				str_repeat('<h2>Headline</h2>',$this->max),
-				[
-					'state' => H2Evaluator::STATE_GREEN,
-					'count' => $this->max
-				]
-			],
-			'seven h2' => [
-				str_repeat('<h2>Headline</h2>',$this->max+1),
-				[
-					'state' => H2Evaluator::STATE_YELLOW,
-					'count' => $this->max+1
-				]
-			],
-		];
-	}
-
+    /**
+     * Dataprovider evaluateTest()
+     *
+     * @return array
+     */
+    public function evaluateTestDataProvider()
+    {
+        return [
+            'zero h2' => [
+                '',
+                [
+                    'count' => 0,
+                    'state' => H2Evaluator::STATE_RED
+                ]
+            ],
+            'one h2' => [
+                '<html><body><h2>Headline One</h2></body></html>',
+                [
+                    'count' => 1,
+                    'state' => H2Evaluator::STATE_GREEN,
+                ]
+            ],
+            'two h2' => [
+                '<h2>Headline One</h2><h2>Headline Two</h2>',
+                [
+                    'state' => H2Evaluator::STATE_GREEN,
+                    'count' => 2
+                ]
+            ],
+            'six h2' => [
+                str_repeat('<h2>Headline</h2>', $this->max),
+                [
+                    'state' => H2Evaluator::STATE_GREEN,
+                    'count' => $this->max
+                ]
+            ],
+            'seven h2' => [
+                str_repeat('<h2>Headline</h2>', $this->max + 1),
+                [
+                    'state' => H2Evaluator::STATE_YELLOW,
+                    'count' => $this->max + 1
+                ]
+            ],
+        ];
+    }
 }

--- a/Tests/Unit/Evaluation/ImagesEvaluatorTest.php
+++ b/Tests/Unit/Evaluation/ImagesEvaluatorTest.php
@@ -33,105 +33,110 @@ use TYPO3\CMS\Core\Tests\UnitTestCase;
 /**
  * @package cs_seo
  */
+class ImagesEvaluatorTest extends UnitTestCase
+{
 
-class ImagesEvaluatorTest extends UnitTestCase {
+    /**
+     * @var ImagesEvaluator
+     */
+    protected $generalEvaluationMock;
 
-	/**
-	 * @var ImagesEvaluator
-	 */
-	protected $generalEvaluationMock;
+    /**
+     * @return void
+     */
+    public function setUp()
+    {
+        $this->generalEvaluationMock = $this->getAccessibleMock(
+            ImagesEvaluator::class,
+            ['dummy'],
+            [new \DOMDocument()]
+        );
+    }
 
-	/**
-	 * @return void
-	 */
-	public function setUp() {
-		$this->generalEvaluationMock = $this->getAccessibleMock(
-			ImagesEvaluator::class,
-			['dummy'],
-			[new \DOMDocument()]
-		);
-	}
+    /**
+     * @return void
+     */
+    public function tearDown()
+    {
+        unset($this->generalEvaluationMock);
+    }
 
-	/**
-	 * @return void
-	 */
-	public function tearDown() {
-		unset($this->generalEvaluationMock);
-	}
+    /**
+     * htmlspecialcharsOnArray Test
+     *
+     * @param string $html
+     * @param mixed $expectedResult
+     *
+     * @dataProvider evaluateTestDataProvider
+     * @return void
+     * @test
+     */
+    public function evaluateTest($html, $expectedResult)
+    {
+        $domDocument = new \DOMDocument();
+        @$domDocument->loadHTML($html);
+        $this->generalEvaluationMock->setDomDocument($domDocument);
+        $result = $this->generalEvaluationMock->evaluate();
 
-	/**
-	 * htmlspecialcharsOnArray Test
-	 *
-	 * @param string $html
-	 * @param mixed $expectedResult
-	 * @dataProvider evaluateTestDataProvider
-	 * @return void
-	 * @test
-	 */
-	public function evaluateTest($html, $expectedResult) {
-		$domDocument = new \DOMDocument();
-		@$domDocument->loadHTML($html);
-		$this->generalEvaluationMock->setDomDocument($domDocument);
-		$result = $this->generalEvaluationMock->evaluate();
+        ksort($expectedResult);
+        ksort($result);
 
-		ksort($expectedResult);
-		ksort($result);
+        $this->assertEquals(json_encode($expectedResult), json_encode($result));
+    }
 
-		$this->assertEquals(json_encode($expectedResult), json_encode($result));
-	}
-
-	/**
-	 * Dataprovider evaluateTest()
-	 *
-	 * @return array
-	 */
-	public function evaluateTestDataProvider() {
-		return [
-			'zero images' => [
-				'',
-				[
-					'count' => 0,
-					'altCount' => 0,
-					'countWithoutAlt' => 0,
-					'state' => AbstractEvaluator::STATE_GREEN
-				]
-			],
-			'one image no alt' => [
-				'<img alt="" />',
-				[
-					'count' => 1,
-					'altCount' => 0,
-					'countWithoutAlt' => 1,
-					'state' => AbstractEvaluator::STATE_RED
-				]
-			],
-			'one image with alt' => [
-				'<img alt="Hallo" />',
-				[
-					'count' => 1,
-					'altCount' => 1,
-					'countWithoutAlt' => 0,
-					'state' => AbstractEvaluator::STATE_GREEN
-				]
-			],
-			'one alt missing' => [
-				'<img alt="" /><img alt="Test" />',
-				[
-					'count' => 2,
-					'altCount' => 1,
-					'countWithoutAlt' => 1,
-					'state' => AbstractEvaluator::STATE_YELLOW
-				]
-			],
-			'3 images with alt' => [
-				str_repeat('<img alt="Test" />', 3),
-				[
-					'count' => 3,
-					'altCount' => 3,
-					'countWithoutAlt' => 0,
-					'state' => AbstractEvaluator::STATE_GREEN
-				]
-			 ]
-		];
-	}
+    /**
+     * Dataprovider evaluateTest()
+     *
+     * @return array
+     */
+    public function evaluateTestDataProvider()
+    {
+        return [
+            'zero images' => [
+                '',
+                [
+                    'count' => 0,
+                    'altCount' => 0,
+                    'countWithoutAlt' => 0,
+                    'state' => AbstractEvaluator::STATE_GREEN
+                ]
+            ],
+            'one image no alt' => [
+                '<img alt="" />',
+                [
+                    'count' => 1,
+                    'altCount' => 0,
+                    'countWithoutAlt' => 1,
+                    'state' => AbstractEvaluator::STATE_RED
+                ]
+            ],
+            'one image with alt' => [
+                '<img alt="Hallo" />',
+                [
+                    'count' => 1,
+                    'altCount' => 1,
+                    'countWithoutAlt' => 0,
+                    'state' => AbstractEvaluator::STATE_GREEN
+                ]
+            ],
+            'one alt missing' => [
+                '<img alt="" /><img alt="Test" />',
+                [
+                    'count' => 2,
+                    'altCount' => 1,
+                    'countWithoutAlt' => 1,
+                    'state' => AbstractEvaluator::STATE_YELLOW
+                ]
+            ],
+            '3 images with alt' => [
+                str_repeat('<img alt="Test" />', 3),
+                [
+                    'count' => 3,
+                    'altCount' => 3,
+                    'countWithoutAlt' => 0,
+                    'state' => AbstractEvaluator::STATE_GREEN
+                ]
+            ]
+        ];
+    }
 }

--- a/Tests/Unit/Evaluation/KeywordEvaluatorTest.php
+++ b/Tests/Unit/Evaluation/KeywordEvaluatorTest.php
@@ -33,154 +33,160 @@ use TYPO3\CMS\Core\Tests\UnitTestCase;
 /**
  * @package cs_seo
  */
-class KeywordEvaluatorTest extends UnitTestCase {
+class KeywordEvaluatorTest extends UnitTestCase
+{
 
-	/**
-	 * @var KeywordEvaluator
-	 */
-	protected $generalEvaluationMock;
+    /**
+     * @var KeywordEvaluator
+     */
+    protected $generalEvaluationMock;
 
-	/**
-	 * @return void
-	 */
-	public function setUp() {
-		$this->generalEvaluationMock = $this->getAccessibleMock(
-			KeywordEvaluator::class,
-			['dummy'],
-			[new \DOMDocument()]
-		);
-	}
+    /**
+     * @return void
+     */
+    public function setUp()
+    {
+        $this->generalEvaluationMock = $this->getAccessibleMock(
+            KeywordEvaluator::class,
+            ['dummy'],
+            [new \DOMDocument()]
+        );
+    }
 
-	/**
-	 * @return void
-	 */
-	public function tearDown() {
-		unset($this->generalEvaluationMock);
-	}
+    /**
+     * @return void
+     */
+    public function tearDown()
+    {
+        unset($this->generalEvaluationMock);
+    }
 
-	/**
-	 * htmlspecialcharsOnArray Test
-	 *
-	 * @param string $html
-	 * @param mixed $expectedResult
-	 * @dataProvider evaluateTestDataProvider
-	 * @return void
-	 * @test
-	 */
-	public function evaluateTest($html, $keyword, $expectedResult) {
-		$domDocument = new \DOMDocument();
-		@$domDocument->loadHTML(mb_convert_encoding($html, 'HTML-ENTITIES', 'UTF-8'));
-		$this->generalEvaluationMock->setDomDocument($domDocument);
-		$this->generalEvaluationMock->setKeyword($keyword);
-		$result = $this->generalEvaluationMock->evaluate();
+    /**
+     * htmlspecialcharsOnArray Test
+     *
+     * @param string $html
+     * @param mixed $expectedResult
+     *
+     * @dataProvider evaluateTestDataProvider
+     * @return void
+     * @test
+     */
+    public function evaluateTest($html, $keyword, $expectedResult)
+    {
+        $domDocument = new \DOMDocument();
+        @$domDocument->loadHTML(mb_convert_encoding($html, 'HTML-ENTITIES', 'UTF-8'));
+        $this->generalEvaluationMock->setDomDocument($domDocument);
+        $this->generalEvaluationMock->setKeyword($keyword);
+        $result = $this->generalEvaluationMock->evaluate();
 
-		ksort($expectedResult);
-		ksort($result);
+        ksort($expectedResult);
+        ksort($result);
 
-		$this->assertEquals(json_encode($expectedResult), json_encode($result));
-	}
+        $this->assertEquals(json_encode($expectedResult), json_encode($result));
+    }
 
-	/**
-	 * Dataprovider evaluateTest()
-	 *
-	 * @return array
-	 */
-	public function evaluateTestDataProvider() {
-		return [
-			'no keyword' => [
-				'',
-				'',
-				[
-					'notSet' => 1,
-					'state' => AbstractEvaluator::STATE_RED
-				]
-			],
-			'keyword set, not found' => [
-				'',
-				'Test',
-				[
-					'contains' => [
-						'title' => 0,
-						'description' => 0,
-						'body' => 0,
-					],
-					'state' => AbstractEvaluator::STATE_YELLOW
-				]
-			],
-			'keyword different case, found in title' => [
-				'<title>Test</title>',
-				'test',
-				[
-					'contains' => [
-						'title' => 1,
-						'description' => 0,
-						'body' => 0,
-					],
-					'state' => AbstractEvaluator::STATE_YELLOW
-				]
-			],
-			'keyword set, found in title' => [
-				'<title>Test</title>',
-				'Test',
-				[
-					'contains' => [
-						'title' => 1,
-						'description' => 0,
-						'body' => 0,
-					],
-					'state' => AbstractEvaluator::STATE_YELLOW
-				]
-			],
-			'keyword set, found in description' => [
-				'<meta name="description" content="Test">',
-				'Test',
-				[
-					'contains' => [
-						'title' => 0,
-						'description' => 1,
-						'body' => 0,
-					],
-					'state' => AbstractEvaluator::STATE_YELLOW
-				]
-			],
-			'keyword set, found in body' => [
-				'<body>Test</body>',
-				'Test',
-				[
-					'contains' => [
-						'title' => 0,
-						'description' => 0,
-						'body' => 1,
-					],
-					'state' => AbstractEvaluator::STATE_YELLOW
-				]
-			],
-			'keyword set, found everywhere UTF-8' => [
-				'<head><title>ÜÄöß</title><meta name="description" content="Test ÜÄöß "></head><body>ÜÄöß Test</body>',
-				'ÜÄöß',
-				[
-					'contains' => [
-						'title' => 1,
-						'description' => 1,
-						'body' => 1,
-					],
-					'state' => AbstractEvaluator::STATE_GREEN
-				]
-			],
-			'keyword set, found everywhere' => [
-				'<head><title>Test Test</title><meta name="description" content="Test this Test"></head><body>Here Test</body>',
-				'Test',
-				[
-					'contains' => [
-						'title' => 2,
-						'description' => 2,
-						'body' => 1,
-					],
-					'state' => AbstractEvaluator::STATE_GREEN
-				]
-			],
-			'keyword alternative set, found everywhere' => [
-				'<head>
+    /**
+     * Dataprovider evaluateTest()
+     *
+     * @return array
+     */
+    public function evaluateTestDataProvider()
+    {
+        return [
+            'no keyword' => [
+                '',
+                '',
+                [
+                    'notSet' => 1,
+                    'state' => AbstractEvaluator::STATE_RED
+                ]
+            ],
+            'keyword set, not found' => [
+                '',
+                'Test',
+                [
+                    'contains' => [
+                        'title' => 0,
+                        'description' => 0,
+                        'body' => 0,
+                    ],
+                    'state' => AbstractEvaluator::STATE_YELLOW
+                ]
+            ],
+            'keyword different case, found in title' => [
+                '<title>Test</title>',
+                'test',
+                [
+                    'contains' => [
+                        'title' => 1,
+                        'description' => 0,
+                        'body' => 0,
+                    ],
+                    'state' => AbstractEvaluator::STATE_YELLOW
+                ]
+            ],
+            'keyword set, found in title' => [
+                '<title>Test</title>',
+                'Test',
+                [
+                    'contains' => [
+                        'title' => 1,
+                        'description' => 0,
+                        'body' => 0,
+                    ],
+                    'state' => AbstractEvaluator::STATE_YELLOW
+                ]
+            ],
+            'keyword set, found in description' => [
+                '<meta name="description" content="Test">',
+                'Test',
+                [
+                    'contains' => [
+                        'title' => 0,
+                        'description' => 1,
+                        'body' => 0,
+                    ],
+                    'state' => AbstractEvaluator::STATE_YELLOW
+                ]
+            ],
+            'keyword set, found in body' => [
+                '<body>Test</body>',
+                'Test',
+                [
+                    'contains' => [
+                        'title' => 0,
+                        'description' => 0,
+                        'body' => 1,
+                    ],
+                    'state' => AbstractEvaluator::STATE_YELLOW
+                ]
+            ],
+            'keyword set, found everywhere UTF-8' => [
+                '<head><title>ÜÄöß</title><meta name="description" content="Test ÜÄöß "></head><body>ÜÄöß Test</body>',
+                'ÜÄöß',
+                [
+                    'contains' => [
+                        'title' => 1,
+                        'description' => 1,
+                        'body' => 1,
+                    ],
+                    'state' => AbstractEvaluator::STATE_GREEN
+                ]
+            ],
+            'keyword set, found everywhere' => [
+                '<head><title>Test Test</title><meta name="description" content="Test this Test"></head><body>Here Test</body>',
+                'Test',
+                [
+                    'contains' => [
+                        'title' => 2,
+                        'description' => 2,
+                        'body' => 1,
+                    ],
+                    'state' => AbstractEvaluator::STATE_GREEN
+                ]
+            ],
+            'keyword alternative set, found everywhere' => [
+                '<head>
 						<title>Test TYPO3</title>
 						<meta name="description" content="Test in TYPO3 like Test TYPO3">
 				</head>
@@ -191,16 +197,16 @@ class KeywordEvaluatorTest extends UnitTestCase {
 					Pellentesque egestas, neque sit amet convallis pulvinar, justo nulla eleifend augue, ac auctor 
 					orci leo non est. Tests TYPO3 Phasellus tempus.
 				</body>',
-				'Test TYPO3, Test in TYPO3, Tests TYPO3',
-				[
-					'contains' => [
-						'title' => 1,
-						'description' => 2,
-						'body' => 2,
-					],
-					'state' => AbstractEvaluator::STATE_GREEN
-				]
-			]
-		];
-	}
+                'Test TYPO3, Test in TYPO3, Tests TYPO3',
+                [
+                    'contains' => [
+                        'title' => 1,
+                        'description' => 2,
+                        'body' => 2,
+                    ],
+                    'state' => AbstractEvaluator::STATE_GREEN
+                ]
+            ]
+        ];
+    }
 }

--- a/Tests/Unit/Evaluation/TitleEvaluatorTest.php
+++ b/Tests/Unit/Evaluation/TitleEvaluatorTest.php
@@ -35,117 +35,118 @@ use TYPO3\CMS\Core\Tests\UnitTestCase;
 class TitleEvaluatorTest extends UnitTestCase
 {
 
-	/**
-	 * @var TitleEvaluator
-	 */
-	protected $generalEvaluationMock;
+    /**
+     * @var TitleEvaluator
+     */
+    protected $generalEvaluationMock;
 
-	/**
-	 * @var int
-	 */
-	protected $min = 40;
+    /**
+     * @var int
+     */
+    protected $min = 40;
 
-	/**
-	 * @var int
-	 */
-	protected $max = 57;
+    /**
+     * @var int
+     */
+    protected $max = 57;
 
-	/**
-	 * @return void
-	 */
-	public function setUp()
-	{
-		$this->generalEvaluationMock = $this->getAccessibleMock(TitleEvaluator::class, ['dummy'], [new \DOMDocument()]);
-		$extConf = [
-			'minTitle' => $this->min,
-			'maxTitle' => $this->max
-		];
-		$GLOBALS['TYPO3_CONF_VARS']['EXT']['extConf']['cs_seo'] = serialize($extConf);
-		$GLOBALS['TYPO3_CONF_VARS']['SYS']['t3lib_cs_utils'] = '';
-	}
+    /**
+     * @return void
+     */
+    public function setUp()
+    {
+        $this->generalEvaluationMock = $this->getAccessibleMock(TitleEvaluator::class, ['dummy'], [new \DOMDocument()]);
+        $extConf = [
+            'minTitle' => $this->min,
+            'maxTitle' => $this->max
+        ];
+        $GLOBALS['TYPO3_CONF_VARS']['EXT']['extConf']['cs_seo'] = serialize($extConf);
+        $GLOBALS['TYPO3_CONF_VARS']['SYS']['t3lib_cs_utils'] = '';
+    }
 
-	/**
-	 * @return void
-	 */
-	public function tearDown()
-	{
-		unset($this->generalEvaluationMock);
-		unset($GLOBALS['TYPO3_CONF_VARS']['EXT']['extConf']['cs_seo']);
-		unset($GLOBALS['TYPO3_CONF_VARS']['SYS']['t3lib_cs_utils']);
-	}
+    /**
+     * @return void
+     */
+    public function tearDown()
+    {
+        unset($this->generalEvaluationMock);
+        unset($GLOBALS['TYPO3_CONF_VARS']['EXT']['extConf']['cs_seo']);
+        unset($GLOBALS['TYPO3_CONF_VARS']['SYS']['t3lib_cs_utils']);
+    }
 
-	/**
-	 * htmlspecialcharsOnArray Test
-	 *
-	 * @param string $html
-	 * @param mixed $expectedResult
-	 * @dataProvider evaluateTestDataProvider
-	 * @return void
-	 * @test
-	 */
-	public function evaluateTest($html, $expectedResult) {
-		$domDocument = new \DOMDocument();
-		@$domDocument->loadHTML(mb_convert_encoding($html, 'HTML-ENTITIES', 'UTF-8'));
-		$this->generalEvaluationMock->setDomDocument($domDocument);
-		$result = $this->generalEvaluationMock->evaluate();
+    /**
+     * htmlspecialcharsOnArray Test
+     *
+     * @param string $html
+     * @param mixed $expectedResult
+     *
+     * @dataProvider evaluateTestDataProvider
+     * @return void
+     * @test
+     */
+    public function evaluateTest($html, $expectedResult)
+    {
+        $domDocument = new \DOMDocument();
+        @$domDocument->loadHTML(mb_convert_encoding($html, 'HTML-ENTITIES', 'UTF-8'));
+        $this->generalEvaluationMock->setDomDocument($domDocument);
+        $result = $this->generalEvaluationMock->evaluate();
 
-		ksort($expectedResult);
-		ksort($result);
+        ksort($expectedResult);
+        ksort($result);
 
-		$this->assertEquals(json_encode($expectedResult), json_encode($result));
-	}
+        $this->assertEquals(json_encode($expectedResult), json_encode($result));
+    }
 
-	/**
-	 * Dataprovider evaluateTest()
-	 *
-	 * @return array
-	 */
-	public function evaluateTestDataProvider()
-	{
-		return [
-			'zero title' => [
-				'',
-				[
-					'count' => 0,
-					'state' => TitleEvaluator::STATE_RED
-				]
-			],
-			'count special chars' => [
-				'<title>ÄÖÜß</title>',
-				[
-					'count' => 4,
-					'state' => TitleEvaluator::STATE_YELLOW,
-				]
-			],
-			'short title' => [
-				'<title>' . str_repeat('.', $this->min-1) . '</title>',
-				[
-					'count' => $this->min-1,
-					'state' => TitleEvaluator::STATE_YELLOW,
-				]
-			],
-			'min good title' => [
-				'<title>' . str_repeat('.', $this->min) . '</title>',
-				[
-					'count' => $this->min,
-					'state' => TitleEvaluator::STATE_GREEN,
-				]
-			],
-			'max good title' => [
-				'<title>' . str_repeat('.', $this->max) . '</title>',
-				[
-					'count' => $this->max,
-					'state' => TitleEvaluator::STATE_GREEN,
-				]
-			],
-			'long title' => [
-				'<title>' . str_repeat('.', $this->max+1) . '</title>',
-				[
-					'count' => $this->max+1,
-					'state' => TitleEvaluator::STATE_YELLOW,
-				]
-			]
-		];
-	}
-
+    /**
+     * Dataprovider evaluateTest()
+     *
+     * @return array
+     */
+    public function evaluateTestDataProvider()
+    {
+        return [
+            'zero title' => [
+                '',
+                [
+                    'count' => 0,
+                    'state' => TitleEvaluator::STATE_RED
+                ]
+            ],
+            'count special chars' => [
+                '<title>ÄÖÜß</title>',
+                [
+                    'count' => 4,
+                    'state' => TitleEvaluator::STATE_YELLOW,
+                ]
+            ],
+            'short title' => [
+                '<title>' . str_repeat('.', $this->min - 1) . '</title>',
+                [
+                    'count' => $this->min - 1,
+                    'state' => TitleEvaluator::STATE_YELLOW,
+                ]
+            ],
+            'min good title' => [
+                '<title>' . str_repeat('.', $this->min) . '</title>',
+                [
+                    'count' => $this->min,
+                    'state' => TitleEvaluator::STATE_GREEN,
+                ]
+            ],
+            'max good title' => [
+                '<title>' . str_repeat('.', $this->max) . '</title>',
+                [
+                    'count' => $this->max,
+                    'state' => TitleEvaluator::STATE_GREEN,
+                ]
+            ],
+            'long title' => [
+                '<title>' . str_repeat('.', $this->max + 1) . '</title>',
+                [
+                    'count' => $this->max + 1,
+                    'state' => TitleEvaluator::STATE_YELLOW,
+                ]
+            ]
+        ];
+    }
 }


### PR DESCRIPTION
I have run all class and test files through the phpcbf --standard=PSR2

There are still some PSR-2 warnings due to HTML content longer than 120 characters, but the code is much more compliant with the TYPO3 coding guidelines