### PR TITLE
[FEATURE] Add emConfiguration to allow analysing pages secured by Bas…

### DIFF
--- a/Classes/Service/FrontendPageService.php
+++ b/Classes/Service/FrontendPageService.php
@@ -82,8 +82,14 @@ class FrontendPageService {
 		$domain = BackendUtility::getViewDomain($pid);
 		$url = $domain . '/index.php?' . $params;
 
+		$headers = null;
+		$emConf = ConfigurationUtility::getEmConfiguration();
+		if ($emConf['basicAuth']) {
+			$headers["Authorization"] = "Basic " . base64_encode($emConf['basicAuthUser'] . ":" . $emConf['basicAuthPass']);
+		}
+
 		$report = [];
-		$content = GeneralUtility::getUrl($url, 0, false, $report);
+		$content = GeneralUtility::getUrl($url, 0, $headers, $report);
 
         if($report['message'] && $report['message'] != 'OK') {
             /** @var \TYPO3\CMS\Core\Messaging\FlashMessage $flashMessage */

--- a/ext_conf_template.txt
+++ b/ext_conf_template.txt
@@ -33,3 +33,12 @@ minDescription = 140
 
 # cat=evaluation/060; type=integer; label= Max number of h2 headlines in one page
 maxH2 = 6
+
+# cat=authentication/010; type=boolean; label= Enable Basic Authentication for analysing the page
+basicAuth = 0
+
+# cat=authentication/020; type=string; label= BasicAuth Username
+basicAuthUser =
+
+# cat=authentication/030; type=string; label= BasicAuth Password
+basicAuthPass =


### PR DESCRIPTION
…ic Authentication

Hi everyone,

really like this extension and tried to analyse pages with it when suddenly - access denied 403. I the page was secured via htaccess Basic Auth.

This provides Basic Authentication configuration to be used by the FrondendPageService, that sets the appropriate headers.
I'd like some feedback regarding the plain text storage of the Basic Auth password, not sure about that one.

Thanks again for this helpful extension and sorry for the long commit message. :)

-
Jonathan