### PR TITLE
[BUGFIX] use page language instead of record language

### DIFF
--- a/Classes/UserFunc/Sitemap.php
+++ b/Classes/UserFunc/Sitemap.php
@@ -131,7 +131,7 @@ class Sitemap {
 							foreach ($records as $key => $record) {
 								$typoLinkConf['additionalParams'] = '&' . $extConf['additionalParams'] . '=' . $record['uid'];
 								if ($record['lang']) {
-									$typoLinkConf['additionalParams'] .= '&L=' . $record['lang'];
+									$typoLinkConf['additionalParams'] .= '&L=' . $this->getTypoScriptFrontendController()->sys_language_uid;
 								}
 								$records[$key]['loc'] = $cObject->typoLink_URL($typoLinkConf);
 							}


### PR DESCRIPTION
We have some news records with sys_language_uid = -1. It was OK to select them, but you can't use that field as L parameter in URL generation.
If you want you also can remove "lang" from SELECT, but please keep it in WHERE.