### PR TITLE
[BUG] twitter:image is a name not a property

### DIFF
--- a/Configuration/TypoScript/Setup/Meta/twitterCards.ts
+++ b/Configuration/TypoScript/Setup/Meta/twitterCards.ts
@@ -59,7 +59,7 @@ page.headerData.654 {
 				forceAbsoluteUrl = 1
 			}
 			required = 1
-			wrap = <meta property="twitter:image" content="|" />
+			wrap = <meta name="twitter:image" content="|" />
 		}
 	}
 }


### PR DESCRIPTION
As shown here: https://dev.twitter.com/cards/types/summary-large-image