### PR TITLE
[FEATURE] add useCacheHash as option in sitemap for extension

### DIFF
--- a/Classes/UserFunc/Sitemap.php
+++ b/Classes/UserFunc/Sitemap.php
@@ -139,6 +139,9 @@ class Sitemap
                                     'parameter' => $detailPid,
                                     'forceAbsoluteUrl' => 1
                                 ];
+                                if (isset($extConf['useCacheHash']) && $extConf['useCacheHash'] === true){
+                                    $typoLinkConf['useCacheHash'] = 1;
+                                }
                                 $typoLinkConf['additionalParams'] =
                                     '&' . $extConf['additionalParams'] . '=' . $record['uid'];
                                 if ($record['lang']) {

--- a/Configuration/TypoScript/Extensions/News/setup.txt
+++ b/Configuration/TypoScript/Extensions/News/setup.txt
@@ -9,6 +9,9 @@ plugin.tx_csseo.sitemap {
 			# string; will be attached to the typolink, more params are possible, the last one is the record param
 			additionalParams = tx_news_pi1[news]
 
+			# boolean; use cHash on url creation
+			useCacheHash = 1
+
 			# string; add custom query options : title LIKE '%top%'
 			additionalWhereClause = type=0
 

--- a/Configuration/TypoScript/Extensions/News/setup.txt
+++ b/Configuration/TypoScript/Extensions/News/setup.txt
@@ -7,7 +7,7 @@ plugin.tx_csseo.sitemap {
 			table = tx_news_domain_model_news
 
 			# string; will be attached to the typolink, more params are possible, the last one is the record param
-			additionalParams = tx_news_pi1[news]
+			additionalParams = tx_news_pi1[controller]=News&tx_news_pi1[action]=detail&tx_news_pi1[news]
 
 			# boolean; use cHash on url creation
 			useCacheHash = 1


### PR DESCRIPTION
I had an issue with wrong url creation in conjunction with the extension realurl. Basically cs_seo generated urls without a cHash parameter which resulted in wrong mappings in realurl.