### PR TITLE
[BUGFIX] Use correct property in documentation for doktypes

### DIFF
--- a/Documentation/Configuration/Sitemap/Index.rst
+++ b/Documentation/Configuration/Sitemap/Index.rst
@@ -63,7 +63,7 @@ Doktypes
 .. container:: table-row
 
    Property
-         languageUids
+         doktypes
    Data type
          :ref:`t3tsref:data-type-list`
    Description


### PR DESCRIPTION
Resolves #128 