### PR TITLE
Update maxDescription value to reflect new Google defaults

### DIFF
--- a/ext_conf_template.txt
+++ b/ext_conf_template.txt
@@ -11,7 +11,7 @@ tsConfigPid = 1
 maxTitle = 57
 
 # cat=page/020; type=integer; label= Max characters of description
-maxDescription = 156
+maxDescription = 300
 
 # cat=page/030; type=integer; label= Max characters of nav title
 maxNavTitle = 50


### PR DESCRIPTION
Based on this article, Google allows description texts with length of up to 300 chars: https://www.sistrix.de/news/google-erlaubt-laengere-snippet-texte/