### PR TITLE
[BUGFIX] Content-Type header for robots.txt

### DIFF
--- a/Configuration/TypoScript/PageTypes/robotsTxt-656.ts
+++ b/Configuration/TypoScript/PageTypes/robotsTxt-656.ts
@@ -13,7 +13,7 @@ pageCsSeoRobotsTxt {
 
 	config {
 		disableAllHeaderCode = 1
-		additionalHeaders = Content-Type:text/plain;charset=utf-8
+		additionalHeaders.10.header = Content-Type:text/plain;charset=utf-8
 		xhtml_cleaning = 0
 		admPanel = 0
 		debug = 0


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | -
| Related issues/PRs | -
| License | GPL-2.0+

#### What's in this PR?

Fixes the TypoScript configuration of the Content-Type header for the robots.txt page type. According to the TypoScript documentation, `config.additionalHeaders` must be an array. Without this, the robots.txt is sent as `text/html`.

##### Documentation reference

- https://docs.typo3.org/typo3cms/TyposcriptReference/7.6/Setup/Config/#additionalheaders
- https://docs.typo3.org/typo3cms/TyposcriptReference/8.7/Setup/Config/#additionalheaders
- https://docs.typo3.org/typo3cms/TyposcriptReference/Setup/Config/#additionalheaders