### PR TITLE
updated "additionalHeaders" for v8.7+, with backwards compatibility

### DIFF
--- a/Configuration/TypoScript/PageTypes/robotsTxt-656.ts
+++ b/Configuration/TypoScript/PageTypes/robotsTxt-656.ts
@@ -41,3 +41,12 @@ pageCsSeoRobotsTxt {
 		stdWrap.ifEmpty.cObject =< plugin.tx_csseo.robots
 	}
 }
+
+[compatVersion = 8.7.0]
+pageCsSeoRobotsTxt {
+	config {
+		additionalHeaders >
+		additionalHeaders.10.header = Content-Type:text/plain;charset=utf-8
+	}
+}
+[end]


### PR DESCRIPTION
In TYPO3 8.7+ the header "Content-Type" was "text/html" 'cos "additionalHeaders" now is an array.

See: https://docs.typo3.org/typo3cms/TyposcriptReference/Setup/Config/Index.html#additionalheaders