### PR TITLE
[BUGFIX] Fix og_image fallback when no cs_seo IRRE-record exists

### DIFF
--- a/Classes/UserFunc/HeaderData.php
+++ b/Classes/UserFunc/HeaderData.php
@@ -150,7 +150,8 @@ class HeaderData
                             if ($seoField == 'og_image' || $seoField == 'tw_image') {
                                 $meta[$seoField] = [
                                     'field' => $fallbackField,
-                                    'table' => $tableSettings['table']
+                                    'table' => $tableSettings['table'],
+                                    'uid_foreign' => $tableSettings['uid']
                                 ];
                             }
                         }
@@ -505,7 +506,7 @@ class HeaderData
         if (is_array($meta[$field])) {
             $params['table'] = $meta[$field]['table'];
             $params['field'] = $meta[$field]['field'];
-            $params['uid'] = $meta['uid_foreign'];
+            $params['uid'] = $meta[$field]['uid_foreign'];
         } else {
             $params['table'] = self::TABLE_NAME_META;
             $params['field'] = 'tx_csseo_' . $field;


### PR DESCRIPTION
When a fallback is defined on a model for og_image/tw_image, and if cs_seo IRRE-record exists,
a php error was thrown: #1316789798: UID of related record has to be an integer. UID given: ""

This commit fixes that issue by using the right uid (record's uid) when loading the image file.

Fixes #92