### PR TITLE
[BUGFIX] Backend styles not loading in production

### DIFF
--- a/Classes/Form/Element/SnippetPreview.php
+++ b/Classes/Form/Element/SnippetPreview.php
@@ -100,10 +100,10 @@ class SnippetPreview extends AbstractNode
         $cssFiles = [
             'Wizard.css'
         ];
-        $baseUrl = ExtensionManagementUtility::siteRelPath('cs_seo') . 'Resources/Public/CSS/';
+        $baseUrl = PathUtility::getAbsoluteWebPath(ExtensionManagementUtility::extPath('cs_seo')) . 'Resources/Public/CSS/';
         // Load the wizards css
         foreach ($cssFiles as $cssFile) {
-            $stylesheetFiles[] = '../'.$baseUrl . $cssFile;
+            $stylesheetFiles[] = $baseUrl . $cssFile;
         }
         return $stylesheetFiles;
     }

--- a/Classes/Form/Element/SnippetPreview.php
+++ b/Classes/Form/Element/SnippetPreview.php
@@ -100,10 +100,10 @@ class SnippetPreview extends AbstractNode
         $cssFiles = [
             'Wizard.css'
         ];
-        $baseUrl = ExtensionManagementUtility::extPath('cs_seo') . 'Resources/Public/CSS/';
+        $baseUrl = ExtensionManagementUtility::siteRelPath('cs_seo') . 'Resources/Public/CSS/';
         // Load the wizards css
         foreach ($cssFiles as $cssFile) {
-            $stylesheetFiles[] = $baseUrl . $cssFile;
+            $stylesheetFiles[] = '../'.$baseUrl . $cssFile;
         }
         return $stylesheetFiles;
     }


### PR DESCRIPTION
Typo3: 8.7.14
cs_seo : dev-master

In production mode, the Wizard.css stylesheet is not loaded correctly. In development mode everything is fine. 

The problems seems to be that in `SnippetPreview->loadCss()` you create an absolute path for the stylesheet that is not supported by `ResourceCompressor->compressCssFile()`. Changing to a relative path seems to fix the issue on my side.