### PR TITLE
add altPageTitle fallback

### DIFF
--- a/Classes/UserFunc/PageTitle.php
+++ b/Classes/UserFunc/PageTitle.php
@@ -59,7 +59,10 @@ class PageTitle
         $page = $this->getPage();
 
         // build the title
-        $title = empty($page['tx_csseo_title']) ? $page['title'] : $page['tx_csseo_title'];
+        $title = $page['tx_csseo_title']
+            ?: $GLOBALS['TSFE']->altPageTitle
+            ?: $page['title']
+        ;
 
         $title = $this->TSFE->getFinalTitle($title, $page['tx_csseo_title_only']);
 


### PR DESCRIPTION
This is related to #162

I added the fallback to altPageTitle if no explicit seo_title is defined.
This will allow news or other extensions to define their own title.