### PR TITLE
[BUGFIX] Fix og:locale in case of config.locale_all contains charset

### DIFF
--- a/Classes/Hook/MetaTagGeneratorHook.php
+++ b/Classes/Hook/MetaTagGeneratorHook.php
@@ -87,7 +87,7 @@ class MetaTagGeneratorHook
             'og:description' => ['value' => $metaData['og_description']],
             'og:image' => ['value' => $ogImageUrl],
             'og:type' => ['value' => $pluginSettings['social.']['openGraph.']['type']],
-            'og:locale' => ['value' => $GLOBALS['TSFE']->config['config']['locale_all']],
+            'og:locale' => ['value' => strstr($GLOBALS['TSFE']->config['config']['locale_all'], '.', true)],
             'twitter:title' => ['value' => $metaData['tw_title']],
             'twitter:description' => ['value' => $metaData['tw_description']],
             'twitter:image' => ['value' => $twImageUrl],


### PR DESCRIPTION
When config.locale_all contains charset (ie. fr_FR.UTF-8), og:locale is malformed.
Facebook Open Graph debugger says it is not a valid enum.

This commit removes the charset part of config.locale_all from og:locale.

Fixes #221