### PR TITLE
[BUGFIX] Fix og:locale in case of config.locale_all contains charset

### DIFF
--- a/Classes/UserFunc/HeaderData.php
+++ b/Classes/UserFunc/HeaderData.php
@@ -412,7 +412,8 @@ class HeaderData
         $metaTags['og:url'] = $this->printMetaTag('og:url', $canonical, 1);
 
         // og:locale
-        $metaTags['og:locale'] = $this->printMetaTag('og:locale', $GLOBALS['TSFE']->config['config']['locale_all'], 1);
+        $ogLocale = strstr($GLOBALS['TSFE']->config['config']['locale_all'], '.', true);
+        $metaTags['og:locale'] = $this->printMetaTag('og:locale', $ogLocale, 1);
 
         // og:site_name
         $metaTags['og:site_name'] = $this->printMetaTag('og:site_name',


### PR DESCRIPTION
When config.locale_all contains charset (ie. fr_FR.UTF-8), og:locale is malformed.
Facebook Open Graph debugger says it is not a valid enum.

This commit removes the charset part of config.locale_all from og:locale.

This is a backport of #222 on 3.1 branch (for TYPO3 8.7)