### PR TITLE
[BUGFIX] remove deprecated getRootline and skip folders in breadcrumb

### DIFF
--- a/Classes/UserFunc/StructuredData.php
+++ b/Classes/UserFunc/StructuredData.php
@@ -118,6 +118,14 @@ class StructuredData
 
         $rootline = GeneralUtility::makeInstance(RootlineUtility::class, $id)->get();
 
+        // remove DOKTYPE_SYSFOLDER from rootline
+        foreach ($rootline as $key => $page) {
+            if ($page['doktype'] === PageRepository::DOKTYPE_SYSFOLDER) {
+                unset($rootline[$key]);
+            }
+        }
+        $rootline = array_values($rootline);
+
         // prevent output of empty rootline
         if (count($rootline) < 2) {
             return '';

--- a/Classes/UserFunc/StructuredData.php
+++ b/Classes/UserFunc/StructuredData.php
@@ -119,12 +119,9 @@ class StructuredData
         $rootline = GeneralUtility::makeInstance(RootlineUtility::class, $id)->get();
 
         // remove DOKTYPE_SYSFOLDER from rootline
-        foreach ($rootline as $key => $page) {
-            if ($page['doktype'] === PageRepository::DOKTYPE_SYSFOLDER) {
-                unset($rootline[$key]);
-            }
-        }
-        $rootline = array_values($rootline);
+        $rootline = array_values(array_filter($rootline, function ($item) {
+            return $item['doktype'] !== PageRepository::DOKTYPE_SYSFOLDER;
+        }));
 
         // prevent output of empty rootline
         if (count($rootline) < 2) {

--- a/Classes/UserFunc/StructuredData.php
+++ b/Classes/UserFunc/StructuredData.php
@@ -28,6 +28,7 @@ namespace Clickstorm\CsSeo\UserFunc;
  ***************************************************************/
 
 use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Core\Utility\RootlineUtility;
 use TYPO3\CMS\Frontend\Page\PageRepository;
 use TYPO3\CMS\Frontend\ContentObject\ContentObjectRenderer;
 
@@ -115,7 +116,7 @@ class StructuredData
             $id = intval($match[1]);
         }
 
-        $rootline = $pageRepository->getRootLine($id);
+        $rootline = GeneralUtility::makeInstance(RootlineUtility::class, $id)->get();
 
         // prevent output of empty rootline
         if (count($rootline) < 2) {


### PR DESCRIPTION
This fixes two current issues:

1.  TYPO3\CMS\Frontend\Page\PageRepository->getRootLine() is deprecated since TYPO3 9.4
(see [https://docs.typo3.org/c/typo3/cms-core/master/en-us/Changelog/9.4/Deprecation-85557-PageRepository-getRootLine.html](https://docs.typo3.org/c/typo3/cms-core/master/en-us/Changelog/9.4/Deprecation-85557-PageRepository-getRootLine.html))
2. Folders are included in the breadcrumb instead of being skipped similar to HMENU