### PR TITLE
[BUGFIX] Fix Regression of #251

### DIFF
--- a/Classes/Controller/ModuleController.php
+++ b/Classes/Controller/ModuleController.php
@@ -713,7 +713,7 @@ class ModuleController extends ActionController
         $dataHandler = $this->getDataHandler();
         $dataHandler->datamap = $data;
         $dataHandler->process_datamap();
-        $response = new HtmlResponse();
+        $response = new HtmlResponse('');
         if (!empty($dataHandler->errorLog)) {
             $response->getBody()->write('Error: ' . implode(',', $dataHandler->errorLog));
         }


### PR DESCRIPTION
HTMLResponse must not be invoked without the content parameter, as reported in https://github.com/clickstorm/cs_seo/issues/244#issuecomment-539313788