### PR TITLE
[BUGFIX] fix Call to a member function stdWrap() on string error

### DIFF
--- a/Classes/Utility/TSFEUtility.php
+++ b/Classes/Utility/TSFEUtility.php
@@ -235,6 +235,10 @@ class TSFEUtility
      */
     public function getPageTitleSeparator()
     {
+        if (empty($GLOBALS['TSFE']->cObj)) {
+            $GLOBALS['TSFE']->cObj = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance('TYPO3\CMS\Frontend\ContentObject\ContentObjectRenderer');
+        }
+        
         return $GLOBALS['TSFE']->cObj->stdWrap(
             $this->config['pageTitleSeparator'],
             $this->config['pageTitleSeparator.']


### PR DESCRIPTION
For some reason the TSFE->cObj is empty when submitting a tx_forms form which leads to the error message "Call to a member function stdWrap() on string" even though the forms action is executed successfully.