### PR TITLE
Bugfix TypoScriptFrontendController

### DIFF
--- a/Classes/Controller/TypoScriptFrontendController.php
+++ b/Classes/Controller/TypoScriptFrontendController.php
@@ -170,7 +170,6 @@ class TypoScriptFrontendController extends \TYPO3\CMS\Frontend\Controller\TypoSc
     public function setSysPageWhereClause()
     {
         $this->sys_page->where_hid_del = '';
-        $this->sys_page->where_groupAccess = '';
     }
 
     /**


### PR DESCRIPTION
#273 Removed setting GroupAccess Where Clause, because it will be occures an QueryBuilder-Exception in backend module (TYPO3 9.5.22). It overwrites the "where_groupAccess" settings in PageRepository, thus building up Where-Clause will failure without any arguments.

