### PR TITLE
Update CurrentUrlGetDataHook.php

### DIFF
--- a/Classes/Hook/CurrentUrlGetDataHook.php
+++ b/Classes/Hook/CurrentUrlGetDataHook.php
@@ -64,7 +64,10 @@ class CurrentUrlGetDataHook implements ContentObjectGetDataHookInterface
         unset($cHash_array['encryptionKey']);
 
         if (ConfigurationUtility::useAdditionalCanonicalizedUrlParametersOnly()) {
-            $canonicalParams = array_flip(explode(',', $GLOBALS['TYPO3_CONF_VARS']['FE']['additionalCanonicalizedUrlParameters']));
+            if(!is_array($GLOBALS['TYPO3_CONF_VARS']['FE']['additionalCanonicalizedUrlParameters'])){
+                $GLOBALS['TYPO3_CONF_VARS']['FE']['additionalCanonicalizedUrlParameters'] = explode(',',$GLOBALS['TYPO3_CONF_VARS']['FE']['additionalCanonicalizedUrlParameters']);
+            }
+            $canonicalParams = array_flip($GLOBALS['TYPO3_CONF_VARS']['FE']['additionalCanonicalizedUrlParameters']);
             $canonicalParams['id'] = $GET['id'];
             $cHash_array = array_intersect_key($cHash_array, $canonicalParams);
         }


### PR DESCRIPTION
in TYPO3 10 additionalCanonicalizedUrlParameters is an array, it shouldn't be exploded if it's already an array.