### PR TITLE
[BUGFIX] fix localization for most BE modules

### DIFF
--- a/Classes/Service/Backend/GridService.php
+++ b/Classes/Service/Backend/GridService.php
@@ -125,7 +125,7 @@ class GridService
         if ($this->modParams['lang'] > 0) {
             /** @var LanguageAspect $languageAspect */
             $languageAspect = GeneralUtility::makeInstance(LanguageAspect::class, $this->modParams['lang']);
-            $context->setAspect('Language', $languageAspect);
+            $context->setAspect('language', $languageAspect);
             $columnDefs[] = $this->getColumnDefinition('sys_language_uid');
         }
 


### PR DESCRIPTION
This commit fixes every BE module except for the "SEO" one. Due to a
typo in the Context configuration the values for each page are always
from the default language. The "SEO" module action works as the
Context is already created in the controller action by creating a
TSFE object.