### PR TITLE
[BUGFIX] Avoid using typed class properties

### DIFF
--- a/Classes/UserFunc/PageTitle.php
+++ b/Classes/UserFunc/PageTitle.php
@@ -15,7 +15,7 @@ final class PageTitle
     /**
      * @var TSFEUtility
      */
-    protected TSFEUtility $TSFEUtility;
+    protected $TSFEUtility;
 
     /**
      * check the settings and may remove the suffix or prefix from the page title


### PR DESCRIPTION
Branch `6x` is targeted for TYPO3 v10 which had a minimum requirement of PHP 7.2. Using class properties requires at least PHP 7.4 and fails in any earlier version.

Related: 66b9253
Fixes: #301