### PR TITLE
[BUGFIX] Labels of noindex nofollow fields and grid view icons

### DIFF
--- a/Classes/Service/Backend/GridService.php
+++ b/Classes/Service/Backend/GridService.php
@@ -160,7 +160,7 @@ class GridService
                     $columnDef['type'] = 'boolean';
                     $columnDef['width'] = 100;
                     $columnDef['cellTemplate'] =
-                        '<div class="ui-grid-cell-contents ng-binding ng-scope text-center"><span class="fa fa-{{row.entity[col.field] == true ? \'check\' : \'remove\'}}"></span></div>';
+                        '<div class="ui-grid-cell-contents ng-binding ng-scope text-center"><span class="fa fa-{{row.entity[col.field] == true ? \'remove\' : \'check\'}}"></span></div>';
                     $columnDef['editableCellTemplate'] =
                         '<div><form name="inputForm" class="text-center"><input type="checkbox" ui-grid-editor ng-model="MODEL_COL_FIELD" ng-click="grid.appScope.currentValue = MODEL_COL_FIELD"></form></div>';
                     $columnDef['enableFiltering'] = false;

--- a/Resources/Private/Language/de.locallang_csh_meta.xlf
+++ b/Resources/Private/Language/de.locallang_csh_meta.xlf
@@ -24,12 +24,12 @@
 				<target>Geben Sie ein Wort oder eine Phrase an. Bei der SEO Evaluation wird dann überprüft, ob das Fokus Schlüsselwort im Browsertitel, der Seitenbeschreibung und im Inhalt gesetzt ist. Sie können mehrere, mit Komma separtierte Alternativen angeben, zum Beispiel für Plural oder enthaltene Stopwörter.</target>
 			</trans-unit>
 			<trans-unit id="no_follow.description" resname="no_follow.description">
-				<source>If checked, all links on the web page will not be checked from search engines. Thus the links have no influence on a page rank.</source>
-				<target>Falls ja, werden die Verlinkungen auf der Seite nicht weiter von Suchmaschinen überprüft. Somit haben sie keinen Einfluss auf das Ranking.</target>
+				<source>If checked, all links on the web page will be checked from search engines. Thus the links have influence on a page rank.</source>
+				<target>Falls ja, werden die Verlinkungen auf der Seite von Suchmaschinen überprüft. Somit haben sie Einfluss auf das Ranking.</target>
 			</trans-unit>
 			<trans-unit id="no_index.description" resname="no_index.description">
-				<source>If checked, this page will not be visible in search engines.</source>
-				<target>Falls ja, wird diese Seite nicht bei den Suchmaschinen angezeigt.</target>
+				<source>If checked, this page will be visible in search engines.</source>
+				<target>Falls ja, wird diese Seite in den Suchmaschinen angezeigt.</target>
 			</trans-unit>
 			<trans-unit id="og_description.description" resname="og_description.description">
 				<source>This description will be shown, if the user shares this page on facebook, LinkedIn etc.</source>

--- a/Resources/Private/Language/de.locallang_csh_pages.xlf
+++ b/Resources/Private/Language/de.locallang_csh_pages.xlf
@@ -24,12 +24,12 @@
 				<target>Geben Sie ein Wort oder eine Phrase an. Bei der SEO Evaluation wird dann überprüft, ob das Fokus Schlüsselwort im Browsertitel, der Seitenbeschreibung und im Inhalt gesetzt ist. Sie können mehrere, mit Komma separtierte Alternativen angeben, zum Beispiel für Plural oder enthaltene Stopwörter.</target>
 			</trans-unit>
 			<trans-unit id="no_follow.description" resname="no_follow.description">
-				<source>If checked, all links on the web page will not be checked from search engines. Thus the links have no influence on a page rank.</source>
-				<target>Falls ja, werden die Verlinkungen auf der Seite nicht weiter von Suchmaschinen überprüft. Somit haben sie keinen Einfluss auf das Ranking.</target>
+				<source>If checked, all links on the web page will be checked from search engines. Thus the links have influence on a page rank.</source>
+				<target>Falls ja, werden die Verlinkungen auf der Seite von Suchmaschinen überprüft. Somit haben sie Einfluss auf das Ranking.</target>
 			</trans-unit>
 			<trans-unit id="no_index.description" resname="no_index.description">
-				<source>If checked, this page will not be visible in search engines.</source>
-				<target>Falls ja, wird diese Seite nicht bei den Suchmaschinen angezeigt.</target>
+				<source>If checked, this page will be visible in search engines.</source>
+				<target>Falls ja, wird diese Seite in den Suchmaschinen angezeigt.</target>
 			</trans-unit>
 			<trans-unit id="og_description.description" resname="og_description.description">
 				<source>This description will be shown, if the user shares this page on facebook, LinkedIn etc.</source>

--- a/Resources/Private/Language/locallang_csh_meta.xlf
+++ b/Resources/Private/Language/locallang_csh_meta.xlf
@@ -19,10 +19,10 @@
 				<source>Specify a word or phrase. In the SEO evaluation will be proofed wether this Focus Keyword is set in the browser title, the meta description and in the page content. You can specify multiple, comma-separated alternatives, e.g. for plural or stop words.</source>
 			</trans-unit>
 			<trans-unit id="no_follow.description" resname="no_follow.description">
-				<source>If checked, all links on the web page will not be checked from search engines. Thus the links have no influence on a page rank.</source>
+				<source>If checked, all links on the web page will be checked from search engines. Thus the links have influence on a page rank.</source>
 			</trans-unit>
 			<trans-unit id="no_index.description" resname="no_index.description">
-				<source>If checked, this page will not be visible in search engines.</source>
+				<source>If checked, this page will be visible in search engines.</source>
 			</trans-unit>
 			<trans-unit id="og_description.description" resname="og_description.description">
 				<source>This description will be shown, if the user shares this page on facebook, LinkedIn etc.</source>

--- a/Resources/Private/Language/locallang_csh_pages.xlf
+++ b/Resources/Private/Language/locallang_csh_pages.xlf
@@ -19,10 +19,10 @@
 				<source>Specify a word or phrase. In the SEO evaluation will be proofed wether this Focus Keyword is set in the browser title, the meta description and in the page content. You can specify multiple, comma-separated alternatives, e.g. for plural or stop words.</source>
 			</trans-unit>
 			<trans-unit id="no_follow.description" resname="no_follow.description">
-				<source>If checked, all links on the web page will not be checked from search engines. Thus the links have no influence on a page rank.</source>
+				<source>If checked, all links on the web page will be checked from search engines. Thus the links have influence on a page rank.</source>
 			</trans-unit>
 			<trans-unit id="no_index.description" resname="no_index.description">
-				<source>If checked, this page will not be visible in search engines.</source>
+				<source>If checked, this page will be visible in search engines.</source>
 			</trans-unit>
 			<trans-unit id="og_description.description" resname="og_description.description">
 				<source>This description will be shown, if the user shares this page on facebook, LinkedIn etc.</source>


### PR DESCRIPTION
This bugfix fixes inconsistent labels for the checkboxes no_index and no_follow that since they were moved to the seo extension with TYPO3 9.  Thereby their values have reversed (for whatever reason).

This circumstance still leads to incorrect statements, e.g. in csh labels.

![Bildschirmfoto 2022-11-17 um 15 23 33](https://user-images.githubusercontent.com/61793007/205552201-92073664-bf5e-40d1-9f75-a79e14507f92.png)

Also the icons in the SEO module show since then inverted states.

![Bildschirmfoto 2022-11-17 um 16 00 34](https://user-images.githubusercontent.com/61793007/205552198-d8fb9205-3e64-4843-9982-f2b8abe295d5.png)
