### PR TITLE
Fix PHP 8.1 Warning: Undefined array key "currentUrl."

### DIFF
--- a/Classes/Service/HrefLangService.php
+++ b/Classes/Service/HrefLangService.php
@@ -29,7 +29,7 @@ class HrefLangService extends AbstractUrlService
         /** @var ContentObjectRenderer $cObj */
         $cObj = GeneralUtility::makeInstance(ContentObjectRenderer::class);
         $context = GeneralUtility::makeInstance(Context::class);
-        $typoLinkConf = $GLOBALS['TSFE']->tmpl->setup['lib.']['currentUrl.']['typolink.'];
+        $typoLinkConf = isset($GLOBALS['TSFE']->tmpl->setup['lib.']['currentUrl.']['typolink.']);
         $tempLinkVars = $GLOBALS['TSFE']->linkVars;
 
         // remove config.linkVars temporary


### PR DESCRIPTION
I had some issues unsing cs_seo unter PHP 8.1 - these changes worked for me.