### PR TITLE
[BUGFIX] type error in 'max' with TYPO3 13.2.0

### DIFF
--- a/Configuration/TCA/Overrides/pages.php
+++ b/Configuration/TCA/Overrides/pages.php
@@ -9,15 +9,18 @@ defined('TYPO3') || die();
 $extConf = ConfigurationUtility::getEmConfiguration();
 
 // SEO Settings
-$GLOBALS['TCA']['pages']['columns']['title']['config']['max'] = $extConf['maxTitle'] ?? '';
-$GLOBALS['TCA']['pages']['columns']['nav_title']['config']['max'] = $extConf['maxNavTitle'] ?? '';
-$GLOBALS['TCA']['pages']['columns']['description']['config']['max'] = $extConf['maxDescription'] ?? '';
+$maxTitleLength = (int)($extConf['maxTitle'] ?? 0);
+$GLOBALS['TCA']['pages']['columns']['title']['config']['max'] = $maxTitleLength ?: null;
+$maxNavTitleLength = (int)($extConf['maxNavTitle'] ?? 0);
+$GLOBALS['TCA']['pages']['columns']['nav_title']['config']['max'] = $maxNavTitleLength ?: null;
+$maxDescriptionLength = (int)($extConf['maxDescription'] ?? 0);
+$GLOBALS['TCA']['pages']['columns']['description']['config']['max'] = $maxDescriptionLength ?: null;
 
 if (!empty($extConf['forceMinDescription'])) {
     $GLOBALS['TCA']['pages']['columns']['description']['config']['min'] = $extConf['minDescription'] ?? '';
 }
 
-$GLOBALS['TCA']['pages']['columns']['seo_title']['config']['max'] = $extConf['maxTitle'] ?? '';
+$GLOBALS['TCA']['pages']['columns']['seo_title']['config']['max'] = $maxTitleLength ?: null;
 $GLOBALS['TCA']['pages']['columns']['seo_title']['config']['renderType'] = 'snippetPreview';
 
 $GLOBALS['TCA']['pages']['columns']['no_index']['onChange'] = 'reload';
@@ -47,7 +50,7 @@ $tempColumns = [
         'exclude' => 1,
         'config' => [
             'type' => 'input',
-            'max' => '40',
+            'max' => 40,
             'eval' => 'trim',
         ],
     ],
@@ -56,7 +59,7 @@ $tempColumns = [
         'exclude' => 1,
         'config' => [
             'type' => 'input',
-            'max' => '40',
+            'max' => 40,
             'eval' => 'trim',
         ],
     ],


### PR DESCRIPTION
With auto-creation of TCA type 'input' fields introduced in TYPO3 13.2.0, the `max` property is now required to be of type int if present. Otherwise, a type error is thrown:

    TypeError: Doctrine\DBAL\Schema\Column::setLength():
        Argument #1 ($length) must be of type ?int, string given,
        called in vendor/doctrine/dbal/src/Schema/Column.php on line 65
    vendor/doctrine/dbal/src/Schema/Column.php:78
    vendor/doctrine/dbal/src/Schema/Column.php:65
    vendor/doctrine/dbal/src/Schema/Column.php:52
    vendor/doctrine/dbal/src/Schema/Table.php:261
    vendor/typo3/cms-core/Classes/Database/Schema/DefaultTcaSchema.php:784
    vendor/typo3/cms-core/Classes/Database/Schema/DefaultTcaSchema.php:70
    vendor/typo3/cms-core/Classes/Database/Schema/SchemaMigrator.php:433
    vendor/typo3/cms-core/Classes/Database/Schema/SchemaMigrator.php:218
    vendor/typo3/cms-core/Classes/Database/Schema/SchemaMigrator.php:149
    vendor/typo3/testing-framework/Classes/Core/Testbase.php:896
    vendor/typo3/testing-framework/Classes/Core/Functional/FunctionalTestCase.php:382

Relates to clickstorm/cs_seo#325.

See: https://github.com/TYPO3/typo3/commit/ee2d3c6db3e193c2ff8c22e6f20d5519c51ae4d2
See: https://github.com/TYPO3/typo3/commit/37a08eaaa3016ec3a65ba45b370733da8ef07762