### PR TITLE
[BUGFIX] Extends existing metaData condition with check on 'false'

### DIFF
--- a/Classes/Service/MetaDataService.php
+++ b/Classes/Service/MetaDataService.php
@@ -33,7 +33,7 @@ class MetaDataService
     public function getMetaData(): array|bool
     {
         // check if metadata was already set
-        if (isset($GLOBALS['TYPO3_CONF_VARS']['EXTENSIONS']['cs_seo']['storage']['metaData'])) {
+        if (isset($GLOBALS['TYPO3_CONF_VARS']['EXTENSIONS']['cs_seo']['storage']['metaData']) && $GLOBALS['TYPO3_CONF_VARS']['EXTENSIONS']['cs_seo']['storage']['metaData'] !== false) {
             return $GLOBALS['TYPO3_CONF_VARS']['EXTENSIONS']['cs_seo']['storage']['metaData'];
         }
 


### PR DESCRIPTION
On the first call to `MetaDataService->getMetaData()`,
`$GLOBALS['TYPO3_CONF_VARS']['EXTENSIONS']['cs_seo']['storage']['metaData']` is already set to `false`.

Because of this, the condition
`if (isset($GLOBALS['TYPO3_CONF_VARS']['EXTENSIONS']['cs_seo']['storage']['metaData']))`
always evaluates to `true`, causing the method to return false immediately. As a result, the meta data processing logic is never reached.

This change addresses the issue by extending the condition to also check for false, ensuring that the meta data processing is executed as intended.