### PR TITLE
fix: use explicit nullable type for PHP 8.4 compatibility for cs_seo 8.x (TYPO3 v12)

### DIFF
--- a/Classes/Service/AbstractUrlService.php
+++ b/Classes/Service/AbstractUrlService.php
@@ -24,7 +24,7 @@ abstract class AbstractUrlService
      * constructor
      */
     public function __construct(
-        TypoScriptFrontendController $typoScriptFrontendController = null
+        ?TypoScriptFrontendController $typoScriptFrontendController = null
     ) {
         if ($typoScriptFrontendController === null) {
             $typoScriptFrontendController = $this->getTypoScriptFrontendController();


### PR DESCRIPTION
### Summary                                                                                                                                                                                                                                                                                                                                                                                                                    
                                                                                                                                                                                                                                                                                                                                                                                                                             
  - Fix implicit nullable parameter in `AbstractUrlService::__construct()` to resolve PHP 8.4 deprecation warning                                                                                                                                                                                                                                                                                                              

###  Details                                                                                                                                                                                                                                                                                                                                                                                                                    
                                                                                                                                                                                                                                                                                                                                                                                                                             
  PHP 8.4 deprecates implicitly nullable parameter types. The `$typoScriptFrontendController` parameter used Type `$param = null` instead of `?Type $param = null`.

```
  Deprecated: Clickstorm\CsSeo\Service\AbstractUrlService::__construct():
  Implicitly marking parameter $typoScriptFrontendController as nullable
  is deprecated, the explicit nullable type must be used instead
```