### PR TITLE
Fix partial GooglePreview leading to empty page property tabs

### DIFF
--- a/Resources/Private/Partials/Wizard/GooglePreview.html
+++ b/Resources/Private/Partials/Wizard/GooglePreview.html
@@ -31,4 +31,4 @@
     </span>
 </div>
 
-<html>
+</html>

--- a/Resources/Private/Partials/Wizard/GooglePreview.html
+++ b/Resources/Private/Partials/Wizard/GooglePreview.html
@@ -1,5 +1,6 @@
-<div xmlns="http://www.w3.org/1999/xhtml" lang="en"
-     xmlns:f="http://typo3.org/ns/fluid/ViewHelpers">
+<html xmlns="http://www.w3.org/1999/xhtml" lang="en"
+     xmlns:f="http://typo3.org/ns/fluid/ViewHelpers"
+      data-namespace-typo3-fluid="true">
 
 <!-- Preview -->
 <div class="tx-cs_seo-preview js-seo-preview">
@@ -29,3 +30,5 @@
           <f:translate key="templates.wizard.description" extensionName="cs_seo" />
     </span>
 </div>
+
+<html>


### PR DESCRIPTION
In TYPO3 14, the single open div leads to all following backend tabs looking empty. All Fields are rendered in the SEO Tab.